### PR TITLE
descriptors and uniforms

### DIFF
--- a/assets/shaders/Builtin.ObjectShader.frag.glsl
+++ b/assets/shaders/Builtin.ObjectShader.frag.glsl
@@ -1,10 +1,10 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
 
-layout(location = 0) in vec3 inPosition;
-
-layout(location = 0) out vec4 out_colour;
+layout(location = 0) out vec4 outColor;
 
 void main() {
-  out_colour = vec4(inPosition.r + 0.5, inPosition.g + 0.5, inPosition.b + 0.5, 1.0);
+  outColor = vec4(1, 0, 0, 1); // RED
 }
+
+

--- a/assets/shaders/Builtin.ObjectShader.vert.glsl
+++ b/assets/shaders/Builtin.ObjectShader.vert.glsl
@@ -2,9 +2,12 @@
 #extension GL_GOOGLE_include_directive : enable
 
 layout(location = 0) in vec3 inPosition;
-layout(location = 0) out vec3 outPosition;
+
+layout(set = 0, binding = 0) uniform globalUniformObject {
+  mat4 projection;
+  mat4 view;
+} globalUbo;
 
 void main() {
-  gl_Position = vec4(inPosition, 1.0);
-  outPosition = inPosition;
+  gl_Position = vec4(inPosition.xy, 0.5, 1.0);
 }

--- a/engine/src/Containers/DArray.hpp
+++ b/engine/src/Containers/DArray.hpp
@@ -50,6 +50,19 @@ public:
   uint64 Length() const { return _length; }
   uint64 Stride() const { return _stride; }
 
+  void Resize(uint64 newLength, bool zeroNewMemory = true) {
+    if (newLength > _capacity) {
+      Reserve(newLength);
+    }
+
+    if (zeroNewMemory && newLength > _length) {
+      uint64 bytes = (newLength - _length) * _stride;
+      _memoryManager.FZeroMemory(AddressOf(_length), bytes);
+    }
+
+    _length = newLength;
+  }
+
   void Reserve(uint64 size) {
     if (size <= _capacity || size < _length) {
       return;

--- a/engine/src/Renderer/RendererFrontend.cc
+++ b/engine/src/Renderer/RendererFrontend.cc
@@ -3,7 +3,7 @@
 #include "Core/FeMemory.hpp"
 #include "Core/Logger.hpp"
 #include "Platform/Filesystem.hpp"
-#include "Renderer/RendererTypes.hpp"
+#include "Renderer/RendererInterface.hpp"
 #include "Renderer/Vulkan/VulkanBackend.hpp"
 
 namespace flatearth::renderer {
@@ -92,10 +92,11 @@ FeExpect<bool, Error> FrontendRenderer::DrawFrame(RenderPacket *pRenderPacket) {
     return FeTrue;
   }
 
-  auto drawRes = _pActiveBackend->DrawFrame(*pRenderPacket);
-  if (!drawRes.has_value()) {
-    FLOG_ERROR("failed to draw frame");
-    return FeErr{drawRes.error()};
+  auto updateRes = _pActiveBackend->UpdateGlobalState(
+      math::Mat4D::Identity(), math::Mat4D::Identity(), math::Vec3D::Zero(), 0);
+  if (!updateRes.has_value()) {
+    FLOG_ERROR("failed to update global state on frontend renderer");
+    return FeErr{updateRes.error()};
   }
 
   auto endRes = EndFrame(pRenderPacket->deltaTime);

--- a/engine/src/Renderer/RendererFrontend.hpp
+++ b/engine/src/Renderer/RendererFrontend.hpp
@@ -5,7 +5,7 @@
 #include "Core/FeMemory.hpp"
 #include "Defines.hpp"
 #include "Platform/Filesystem.hpp"
-#include "Renderer/RendererTypes.hpp"
+#include "Renderer/RendererInterface.hpp"
 
 namespace flatearth::renderer {
 

--- a/engine/src/Renderer/RendererInterface.hpp
+++ b/engine/src/Renderer/RendererInterface.hpp
@@ -1,0 +1,41 @@
+#ifndef _FLATEARHT_ENGINE_RENDERER_INTERFACE_HPP
+#define _FLATEARHT_ENGINE_RENDERER_INTERFACE_HPP
+
+#include "Core/ApplicationConfig.hpp"
+#include "Defines.hpp"
+
+namespace flatearth::renderer {
+
+enum class BackendType {
+  Vulkan = 0,
+  OpenGL,
+  DirectX,
+  MaxBackends,
+};
+
+static constexpr int32 scMaxBackends =
+    static_cast<int32>(BackendType::MaxBackends);
+
+struct RenderPacket {
+  float32 deltaTime;
+};
+
+class IRendererBackend {
+public:
+  virtual FeExpect<bool, Error> Initialize(ApplicationState *appState) = 0;
+  virtual FeExpect<bool, Error> OnResize(uint32 width, uint32 height) = 0;
+  virtual FeExpect<bool, Error> BeginFrame(float32 deltaTime) = 0;
+  virtual FeExpect<bool, Error> EndFrame(float32 deltaTime) = 0;
+  virtual FeExpect<bool, Error> DrawFrame(const RenderPacket &renderPacket) = 0;
+  virtual FeExpect<void, Error> UpdateGlobalState(math::Mat4D projection,
+                                                  math::Mat4D view,
+                                                  math::Vec3D viewPosition,
+                                                  int32 mode) = 0;
+
+protected:
+  virtual ~IRendererBackend() = default;
+};
+
+} // namespace flatearth::renderer
+
+#endif // _FLATEARHT_ENGINE_RENDERER_INTERFACE_HPP

--- a/engine/src/Renderer/RendererTypes.hpp
+++ b/engine/src/Renderer/RendererTypes.hpp
@@ -1,35 +1,15 @@
 #ifndef _FLATEARHT_ENGINE_RENDERER_TYPES_HPP
 #define _FLATEARHT_ENGINE_RENDERER_TYPES_HPP
 
-#include "Core/ApplicationConfig.hpp"
-#include "Defines.hpp"
+#include "Math/Matrix4D.hpp"
 
 namespace flatearth::renderer {
 
-enum class BackendType {
-  Vulkan = 0,
-  OpenGL,
-  DirectX,
-  MaxBackends,
-};
-
-static constexpr int32 scMaxBackends =
-    static_cast<int32>(BackendType::MaxBackends);
-
-struct RenderPacket {
-  float32 deltaTime;
-};
-
-class IRendererBackend {
-public:
-  virtual FeExpect<bool, Error> Initialize(ApplicationState *appState) = 0;
-  virtual FeExpect<bool, Error> OnResize(uint32 width, uint32 height) = 0;
-  virtual FeExpect<bool, Error> BeginFrame(float32 deltaTime) = 0;
-  virtual FeExpect<bool, Error> EndFrame(float32 deltaTime) = 0;
-  virtual FeExpect<bool, Error> DrawFrame(const RenderPacket &renderPacket) = 0;
-
-protected:
-  virtual ~IRendererBackend() = default;
+struct GlobalUniformObject {
+  math::Mat4D projection, view;
+  // These below are so that GlobalUniformObject always
+  // has a size of 256 bytes
+  math::Mat4D reservedSpace1, reservedSpace2;
 };
 
 } // namespace flatearth::renderer

--- a/engine/src/Renderer/Vulkan/Shaders/ObjectShader.cc
+++ b/engine/src/Renderer/Vulkan/Shaders/ObjectShader.cc
@@ -1,13 +1,15 @@
 #include "ObjectShader.hpp"
 #include "Math/Vector3D.hpp"
+#include "Renderer/RendererTypes.hpp"
 #include "Renderer/Vulkan/VulkanTypes.hpp"
 #include "Renderer/Vulkan/VulkanUtils.hpp"
 #include <vulkan/vulkan_core.h>
 
 namespace flatearth::renderer::vulkan::shaders {
 
-VulkanShader::VulkanShader(memory::MemoryManager &memManager)
-    : _memoryManager(memManager) {}
+VulkanShader::VulkanShader(memory::MemoryManager &memManager,
+                           BufferManager &bufferManager)
+    : _memoryManager(memManager), _bufferManager(bufferManager) {}
 
 VulkanShader::~VulkanShader() {
   FLOG_INFO("vulkan shader successfully destroyed");
@@ -44,7 +46,54 @@ VulkanShader::CreateObjectShader(Context &ctx, ObjectShader *pObjShader) {
     FLOG_INFO("{} object shader created", cStageTypeStrs[i]);
   }
 
-  VkViewport viewport;
+  // -----------------------------
+  // Global descriptor set layout
+  // -----------------------------
+  VkDescriptorSetLayoutBinding globalUBOLayoutBinding{};
+  globalUBOLayoutBinding.binding = 0;
+  globalUBOLayoutBinding.descriptorCount = 1;
+  globalUBOLayoutBinding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+  globalUBOLayoutBinding.pImmutableSamplers = nullptr;
+  globalUBOLayoutBinding.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+
+  VkDescriptorSetLayoutCreateInfo layoutCreateInfo{
+      VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
+  layoutCreateInfo.bindingCount = 1;
+  layoutCreateInfo.pBindings = &globalUBOLayoutBinding;
+
+  if (auto res = VkCheck(vkCreateDescriptorSetLayout(
+          ctx.device.logicalDevice, &layoutCreateInfo, ctx.pAllocator,
+          &pObjShader->globalDescriptorSetLayout));
+      !res.has_value()) {
+    FLOG_ERROR("failed to create descriptor set layout");
+    return FeErr{res.error()};
+  }
+
+  // -----------------------------
+  // Descriptor pool
+  // -----------------------------
+  VkDescriptorPoolSize globalPoolSize{};
+  globalPoolSize.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+  globalPoolSize.descriptorCount = ctx.swapchain.imageCount; // 1 UBO per set
+
+  VkDescriptorPoolCreateInfo poolInfo{
+      VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
+  poolInfo.poolSizeCount = 1;
+  poolInfo.pPoolSizes = &globalPoolSize;
+  poolInfo.maxSets = ctx.swapchain.imageCount;
+
+  if (auto res = VkCheck(vkCreateDescriptorPool(
+          ctx.device.logicalDevice, &poolInfo, ctx.pAllocator,
+          &pObjShader->globalDescriptorPool));
+      !res.has_value()) {
+    FLOG_ERROR("failed to create descriptor pool");
+    return FeErr{res.error()};
+  }
+
+  // -----------------------------
+  // Pipeline creation
+  // -----------------------------
+  VkViewport viewport{};
   viewport.x = 0.0f;
   viewport.y = 0.0f;
   viewport.width = static_cast<float32>(ctx.framebufferWidth);
@@ -52,18 +101,20 @@ VulkanShader::CreateObjectShader(Context &ctx, ObjectShader *pObjShader) {
   viewport.minDepth = 0.0f;
   viewport.maxDepth = 1.0f;
 
-  VkRect2D scissor;
-  scissor.offset.x = scissor.offset.y = 0;
+  VkRect2D scissor{};
+  scissor.offset.x = 0;
+  scissor.offset.y = 0;
   scissor.extent.width = ctx.framebufferWidth;
   scissor.extent.height = ctx.framebufferHeight;
 
   uint32 offset = 0;
   const int32 attributeCount = 1;
-  std::array<VkVertexInputAttributeDescription, attributeCount> attrDescription;
+  std::array<VkVertexInputAttributeDescription, attributeCount>
+      attrDescription{};
   std::array<VkFormat, attributeCount> formats = {VK_FORMAT_R32G32B32_SFLOAT};
   std::array<uint32, attributeCount> sizes = {sizeof(math::Vec3D)};
 
-  for (uint32 i = 0; i < attributeCount; i++) {
+  for (uint32 i = 0; i < static_cast<uint32>(attributeCount); i++) {
     attrDescription[i].binding = 0;
     attrDescription[i].location = i;
     attrDescription[i].format = formats[i];
@@ -71,38 +122,126 @@ VulkanShader::CreateObjectShader(Context &ctx, ObjectShader *pObjShader) {
     offset += sizes[i];
   }
 
-  // Stages
+  // Descriptor set layouts for pipeline layout
+  const uint64 cLayoutCount = 1;
+  std::array<VkDescriptorSetLayout, cLayoutCount> layouts = {
+      pObjShader->globalDescriptorSetLayout,
+  };
+
+  // Shader stages
   std::array<VkPipelineShaderStageCreateInfo, cObjectShaderStageCount>
-      stageInfos;
+      stageInfos{};
   _memoryManager.FZeroMemory(stageInfos.data(), sizeof(stageInfos));
   for (uint32 i = 0; i < cObjectShaderStageCount; i++) {
-    stageInfos[i].sType =
-        pObjShader->shaderStages[i].shaderStageCreateInfo.sType;
     stageInfos[i] = pObjShader->shaderStages[i].shaderStageCreateInfo;
   }
 
   auto pipelineRes = _pipelineManager.CreateGraphicsPipeline(
-      ctx, &ctx.mainRenderpass, attributeCount, attrDescription.data(), 0, 0,
-      cObjectShaderStageCount, stageInfos.data(), viewport, scissor, FeFalse,
-      &pObjShader->pipeline);
+      ctx, &ctx.mainRenderpass, attributeCount, attrDescription.data(),
+      cLayoutCount, layouts.data(), cObjectShaderStageCount, stageInfos.data(),
+      viewport, scissor, FeFalse, &pObjShader->pipeline);
   if (!pipelineRes.has_value()) {
     FLOG_ERROR("failed to create graphics pipeline");
     return FeErr{pipelineRes.error()};
   }
 
+  // -----------------------------
+  // Global uniform buffer (host visible)
+  // -----------------------------
+  VkBufferUsageFlags usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+  uint32 memFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                    VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+
+  auto createBufferRes = _bufferManager.CreateVulkanBuffer(
+      ctx, sizeof(GlobalUniformObject), usage, memFlags, FeTrue,
+      &pObjShader->globalUniformBuffer);
+  if (!createBufferRes.has_value()) {
+    FLOG_ERROR("failed to create vulkan buffer for GlobalUniformObject");
+    return FeErr{createBufferRes.error()};
+  }
+
+  // -----------------------------
+  // Allocate global descriptor sets (ONE PER SWAPCHAIN IMAGE)
+  // -----------------------------
+  const uint32 count = ctx.swapchain.imageCount;
+
+  // Resize DArray<VkDescriptorSet>
+  pObjShader->globalDescriptorSets.Resize(count);
+
+  // Build a layouts array (count copies)
+  containers::DArray<VkDescriptorSetLayout> globalLayouts(_memoryManager);
+  globalLayouts.Resize(count);
+  for (uint32 i = 0; i < count; ++i) {
+    globalLayouts[i] = pObjShader->globalDescriptorSetLayout;
+  }
+
+  VkDescriptorSetAllocateInfo allocInfo{
+      VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
+  allocInfo.descriptorPool = pObjShader->globalDescriptorPool;
+  allocInfo.descriptorSetCount = count;
+  allocInfo.pSetLayouts = globalLayouts.Data();
+
+  if (auto res = VkCheck(
+          vkAllocateDescriptorSets(ctx.device.logicalDevice, &allocInfo,
+                                   pObjShader->globalDescriptorSets.Data()));
+      !res.has_value()) {
+    FLOG_ERROR("failed to allocate descriptor sets");
+    return FeErr{res.error()};
+  }
+
+  containers::DArray<VkDescriptorBufferInfo> infos(_memoryManager);
+  containers::DArray<VkWriteDescriptorSet> writes(_memoryManager);
+  infos.Resize(count);
+  writes.Resize(count);
+
+  for (uint32 i = 0; i < count; ++i) {
+    infos[i] = {};
+    infos[i].buffer = pObjShader->globalUniformBuffer.handle;
+    infos[i].offset = 0;
+    infos[i].range = sizeof(GlobalUniformObject);
+
+    writes[i] = {};
+    writes[i].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    writes[i].dstSet = pObjShader->globalDescriptorSets[i];
+    writes[i].dstBinding = 0;
+    writes[i].dstArrayElement = 0;
+    writes[i].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    writes[i].descriptorCount = 1;
+    writes[i].pBufferInfo = &infos[i];
+  }
+
+  vkUpdateDescriptorSets(ctx.device.logicalDevice, count, writes.Data(), 0,
+                         nullptr);
+
   return FeTrue;
 }
 
 void VulkanShader::DestroyObjectShader(Context &ctx, ObjectShader *pObjShader) {
-  if (pObjShader == nullptr) {
-    return;
+  if (!pObjShader) return;
+
+  VkDevice dev = ctx.device.logicalDevice;
+
+  vkDeviceWaitIdle(dev);
+
+  if (pObjShader->globalDescriptorPool) {
+    vkDestroyDescriptorPool(dev, pObjShader->globalDescriptorPool, ctx.pAllocator);
+    pObjShader->globalDescriptorPool = VK_NULL_HANDLE;
   }
 
+  if (pObjShader->globalDescriptorSetLayout) {
+    vkDestroyDescriptorSetLayout(dev, pObjShader->globalDescriptorSetLayout, ctx.pAllocator);
+    pObjShader->globalDescriptorSetLayout = VK_NULL_HANDLE;
+  }
+
+  _bufferManager.DestroyVulkanBuffer(ctx, &pObjShader->globalUniformBuffer);
+
   _pipelineManager.DestroyGraphicsPipeline(ctx, &pObjShader->pipeline);
+
   for (uint32 i = 0; i < cObjectShaderStageCount; i++) {
-    vkDestroyShaderModule(ctx.device.logicalDevice,
-                          pObjShader->shaderStages[i].handle, ctx.pAllocator);
-    pObjShader->shaderStages[i].handle = nullptr;
+    if (pObjShader->shaderStages[i].handle) {
+      vkDestroyShaderModule(dev, pObjShader->shaderStages[i].handle, ctx.pAllocator);
+      pObjShader->shaderStages[i].handle = VK_NULL_HANDLE;
+    }
   }
 }
 
@@ -112,5 +251,26 @@ void VulkanShader::UseShader(Context &ctx, ObjectShader &objShader) {
   _pipelineManager.BindPipeline(ctx.graphicsCommandBuffer[imageIndex],
                                 bindPoint, objShader.pipeline);
 }
+
+
+FeExpect<void, Error>
+VulkanShader::UpdateGlobalState(Context &ctx, ObjectShader &objShader) {
+  constexpr uint32 cRange  = sizeof(GlobalUniformObject);
+  constexpr uint64 cOffset = 0;
+
+  auto loadRes = _bufferManager.LoadData(ctx,
+                                        objShader.globalUniformBuffer,
+                                        cOffset,
+                                        cRange,
+                                        0,
+                                        &objShader.globalUBO);
+  if (!loadRes.has_value()) {
+    FLOG_ERROR("failed to load data while updating global state");
+    return FeErr{loadRes.error()};
+  }
+
+  return {};
+}
+
 
 } // namespace flatearth::renderer::vulkan::shaders

--- a/engine/src/Renderer/Vulkan/Shaders/ObjectShader.hpp
+++ b/engine/src/Renderer/Vulkan/Shaders/ObjectShader.hpp
@@ -1,6 +1,7 @@
 #ifndef _FLATEARTH_ENGINE_RENDERER_VULKAN_SHADERS_OBJECT_SHADER_HPP
 #define _FLATEARTH_ENGINE_RENDERER_VULKAN_SHADERS_OBJECT_SHADER_HPP
 
+#include "Renderer/Vulkan/VulkanBuffer.hpp"
 #include "Renderer/Vulkan/VulkanPipeline.hpp"
 #include "Renderer/Vulkan/VulkanTypes.hpp"
 
@@ -8,7 +9,8 @@ namespace flatearth::renderer::vulkan::shaders {
 
 class VulkanShader {
 public:
-  explicit VulkanShader(memory::MemoryManager &memManager);
+  explicit VulkanShader(memory::MemoryManager &memManager,
+                        BufferManager &bufferManager);
   ~VulkanShader();
 
   FeExpect<bool, Error> CreateObjectShader(Context &ctx,
@@ -16,9 +18,11 @@ public:
   void DestroyObjectShader(Context &ctx, ObjectShader *pObjShader);
 
   void UseShader(Context &ctx, ObjectShader &objShader);
+  FeExpect<void, Error> UpdateGlobalState(Context &ctx, ObjectShader &objShader);
 
 private:
   memory::MemoryManager &_memoryManager;
+  BufferManager &_bufferManager;
   PipelineManager _pipelineManager;
 };
 

--- a/engine/src/Renderer/Vulkan/VulkanBackend.cc
+++ b/engine/src/Renderer/Vulkan/VulkanBackend.cc
@@ -18,8 +18,8 @@ VulkanBackend::VulkanBackend(memory::MemoryManager &memManager,
     : _memoryManager(memManager), _deviceManager(memManager),
       _swapchainManager(memManager, _imageManager),
       _renderpassManager(memManager), _cmdBufferManager(memManager),
-      _bufferManager(_cmdBufferManager), _vulkanShader(memManager),
-      _ctx(memManager, fs) {}
+      _bufferManager(_cmdBufferManager),
+      _vulkanShader(memManager, _bufferManager), _ctx(memManager, fs) {}
 
 VulkanBackend::~VulkanBackend() {
   vkDeviceWaitIdle(_ctx.device.logicalDevice);
@@ -344,7 +344,6 @@ FeExpect<bool, Error> VulkanBackend::Initialize(ApplicationState *appState) {
   const uint32 cIndexCount = 6;
   std::array<uint32, cIndexCount> indicies = {0, 2, 1, 0, 3, 1};
 
-
   VkFence tempFence;
   VkFenceCreateInfo fenceInfo = {VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
   vkCreateFence(_ctx.device.logicalDevice, &fenceInfo, _ctx.pAllocator,
@@ -468,8 +467,6 @@ FeExpect<bool, Error> VulkanBackend::BeginFrame(float32 deltaTime) {
   scissor.offset = {0, 0};
   scissor.extent = {_ctx.framebufferWidth, _ctx.framebufferHeight};
 
-
-
   constexpr uint32 cFirstViewport = 0;
   constexpr uint32 cViewportCount = 1;
   constexpr uint32 cFirstScissor = 0;
@@ -481,8 +478,18 @@ FeExpect<bool, Error> VulkanBackend::BeginFrame(float32 deltaTime) {
 
   _vulkanShader.UseShader(_ctx, _ctx.objectShader);
 
-  // TODO: remove (for tests)
+  {
+    VkDescriptorSet set0 = _ctx.objectShader.globalDescriptorSets[_ctx.imageIndex];
+    vkCmdBindDescriptorSets(
+        cmdBuffer.handle,
+        VK_PIPELINE_BIND_POINT_GRAPHICS,
+        _ctx.objectShader.pipeline.layout,
+        0, 1,
+        &set0,
+        0, nullptr);
+  }
 
+  // TODO: remove (for tests)
   std::array<VkDeviceSize, 1> offsets = {0};
 
   vkCmdSetViewport(cmdBuffer.handle, cFirstViewport, cViewportCount, &viewport);
@@ -496,7 +503,6 @@ FeExpect<bool, Error> VulkanBackend::BeginFrame(float32 deltaTime) {
                        VK_INDEX_TYPE_UINT32);
 
   vkCmdDrawIndexed(cmdBuffer.handle, 6, 1, 0, 0, 0);
-
   return FeTrue;
 }
 
@@ -565,7 +571,8 @@ FeExpect<bool, Error> VulkanBackend::EndFrame(float32 deltaTime) {
   return FeTrue;
 }
 
-FeExpect<bool, Error> VulkanBackend::DrawFrame(const RenderPacket &renderPacket) {
+FeExpect<bool, Error>
+VulkanBackend::DrawFrame(const RenderPacket &renderPacket) {
   if (_ctx.recreatingSwapchain) {
     return FeFalse;
   }
@@ -575,6 +582,9 @@ FeExpect<bool, Error> VulkanBackend::DrawFrame(const RenderPacket &renderPacket)
   CommandBuffer &cmdBuffer = _ctx.graphicsCommandBuffer[_ctx.imageIndex];
 
   _vulkanShader.UseShader(_ctx, _ctx.objectShader);
+
+
+
   VkDeviceSize offset = 0;
   vkCmdBindVertexBuffers(cmdBuffer.handle, 0, 1,
                          &_ctx.objectVertexBuffer.handle, &offset);
@@ -585,6 +595,26 @@ FeExpect<bool, Error> VulkanBackend::DrawFrame(const RenderPacket &renderPacket)
   // Draw quad (6 indices)
   vkCmdDrawIndexed(cmdBuffer.handle, 6, 1, 0, 0, 0);
   return FeTrue;
+}
+
+FeExpect<void, Error> VulkanBackend::UpdateGlobalState(math::Mat4D projection,
+                                                       math::Mat4D view,
+                                                       math::Vec3D viewPosition,
+                                                       int32 mode) {
+  CommandBuffer &cmdBuffer = _ctx.graphicsCommandBuffer[_ctx.imageIndex];
+  _vulkanShader.UseShader(_ctx, _ctx.objectShader);
+
+  _ctx.objectShader.globalUBO.projection = projection;
+  _ctx.objectShader.globalUBO.view = view;
+  // TODO: other ubo properties
+  
+  auto updateRes = _vulkanShader.UpdateGlobalState(_ctx, _ctx.objectShader);
+  if (!updateRes.has_value()) {
+    FLOG_ERROR("failed to update global state");
+    return FeErr{updateRes.error()};
+  }
+
+  return {};
 }
 
 // PRIVATE MEMBERS

--- a/engine/src/Renderer/Vulkan/VulkanBackend.hpp
+++ b/engine/src/Renderer/Vulkan/VulkanBackend.hpp
@@ -4,20 +4,21 @@
 #include "Core/ApplicationConfig.hpp"
 #include "Core/FeMemory.hpp"
 #include "Platform/Filesystem.hpp"
-#include "Renderer/RendererTypes.hpp"
-#include "Renderer/Vulkan/VulkanBuffer.hpp"
+#include "Renderer/RendererInterface.hpp"
 #include "Renderer/Vulkan/Shaders/ObjectShader.hpp"
+#include "Renderer/Vulkan/VulkanBuffer.hpp"
+#include "Renderer/Vulkan/VulkanCommandBufferManager.hpp"
 #include "Renderer/Vulkan/VulkanDeviceManager.hpp"
 #include "Renderer/Vulkan/VulkanImager.hpp"
 #include "Renderer/Vulkan/VulkanRenderpassManager.hpp"
 #include "Renderer/Vulkan/VulkanSwapchainManager.hpp"
-#include "Renderer/Vulkan/VulkanCommandBufferManager.hpp"
 
 namespace flatearth::renderer::vulkan {
 
 class VulkanBackend : public IRendererBackend {
 public:
-  explicit VulkanBackend(memory::MemoryManager &memManager, platform::FileSystem &fs);
+  explicit VulkanBackend(memory::MemoryManager &memManager,
+                         platform::FileSystem &fs);
   ~VulkanBackend();
 
   FeExpect<bool, Error> Initialize(ApplicationState *appState) override;
@@ -25,6 +26,10 @@ public:
   FeExpect<bool, Error> BeginFrame(float32 deltaTime) override;
   FeExpect<bool, Error> EndFrame(float32 deltaTime) override;
   FeExpect<bool, Error> DrawFrame(const RenderPacket &renderPacket) override;
+  FeExpect<void, Error> UpdateGlobalState(math::Mat4D projection,
+                                          math::Mat4D view,
+                                          math::Vec3D viewPosition,
+                                          int32 mode) override;
 
 private:
   FeExpect<void, Error> CreateFence(Fence *pFence, bool signaled);
@@ -32,8 +37,10 @@ private:
   FeExpect<bool, Error> AwaitFence(Fence *pFence, uint64 timeoutNs);
   FeExpect<void, Error> ResetFence(Fence *pFence);
   FeExpect<void, Error> CreateBuffers();
-  FeExpect<void, Error> UploadDataRange(VkCommandPool pool, VkFence fence, VkQueue queue, uint64 offset, uint64 size, VulkanBuffer &buffer, void *pData);
-
+  FeExpect<void, Error> UploadDataRange(VkCommandPool pool, VkFence fence,
+                                        VkQueue queue, uint64 offset,
+                                        uint64 size, VulkanBuffer &buffer,
+                                        void *pData);
 
 private:
   memory::MemoryManager &_memoryManager;
@@ -44,7 +51,7 @@ private:
   CommandBufferManager _cmdBufferManager;
   BufferManager _bufferManager;
   shaders::VulkanShader _vulkanShader;
-    // No-op (not an error)
+  // No-op (not an error)
   Context _ctx;
 
   uint32 _cachedFrameBufferWidth{0}, _cachedFrameBufferHeight{0};

--- a/engine/src/Renderer/Vulkan/VulkanTypes.hpp
+++ b/engine/src/Renderer/Vulkan/VulkanTypes.hpp
@@ -7,12 +7,14 @@
 #include "Defines.hpp"
 #include "Error.hpp"
 #include "Platform/Filesystem.hpp"
+#include "Renderer/RendererTypes.hpp"
 #include <vulkan/vulkan.h>
 #include <vulkan/vulkan_core.h>
 
 namespace flatearth::renderer::vulkan {
 
 constexpr uint32 cObjectShaderStageCount = 2;
+constexpr uint32 cDescriptorSetCount = 3;
 
 inline FeExpect<void, Error> VkCheck(VkResult result) {
   if (result != VK_SUCCESS) {
@@ -180,8 +182,6 @@ struct ShaderStage {
   VkShaderModule handle;
   VkShaderModuleCreateInfo shaderModuleCreateInfo;
   VkPipelineShaderStageCreateInfo shaderStageCreateInfo;
-
-  
 };
 
 struct Pipeline {
@@ -192,6 +192,18 @@ struct Pipeline {
 struct ObjectShader {
   std::array<ShaderStage, cObjectShaderStageCount> shaderStages;
   Pipeline pipeline;
+
+  VkDescriptorPool globalDescriptorPool;
+  VkDescriptorSetLayout globalDescriptorSetLayout;
+
+  containers::DArray<VkDescriptorSet> globalDescriptorSets;
+
+  // Global uniform object
+  GlobalUniformObject globalUBO;
+  VulkanBuffer globalUniformBuffer;
+
+  ObjectShader(memory::MemoryManager &memManager)
+      : globalDescriptorSets(memManager) {}
 };
 
 struct Context {
@@ -226,12 +238,12 @@ struct Context {
 
   bool recreatingSwapchain{false};
 
-
   explicit Context(memory::MemoryManager &memManager, platform::FileSystem &fs)
       : swapchain(memManager), graphicsCommandBuffer(memManager),
         imageAvailableSemaphores(memManager),
         queueCompleteSemaphores(memManager), inFlightFences(memManager),
-        imagesInFlight(memManager), memoryManager(memManager), filesystem(fs) {}
+        imagesInFlight(memManager), memoryManager(memManager), filesystem(fs),
+        objectShader(memManager) {}
 
   int32 FindMemoryIndex(uint32 typeFilter, uint32 propertyFlags) {
     VkPhysicalDeviceMemoryProperties memoryProps;


### PR DESCRIPTION
This pull request introduces significant improvements to the renderer's architecture, focusing on separating interface definitions, improving Vulkan shader resource management, and updating shader code for better uniform handling. The changes enhance modularity, resource management, and prepare the codebase for more advanced rendering features.

### Renderer Interface & Type Refactoring

* Moved renderer backend interface and related types (`BackendType`, `RenderPacket`, `IRendererBackend`) from `RendererTypes.hpp` to a new dedicated file `RendererInterface.hpp`, improving code organization and separation of concerns. Includes updates to all relevant includes. [[1]](diffhunk://#diff-cfe671ce89612bd20b400e9359720b4d24df386bf15924257688816880ca5c50R1-R41) [[2]](diffhunk://#diff-c1832aa357d5f8c0b157ad91003e441db43527affe3524cc35007d94af5e5694L6-R6) [[3]](diffhunk://#diff-91822889704061f91d0769ed5370d69eb5ef3c7ddccfd01d29b4816002ac6d0eL8-R8) [[4]](diffhunk://#diff-a8f9c3a2cbd119f6906b34db8089d260f827b3cc1f173f6c5083b6e7d3714a88L4-R12)

* Updated `RendererTypes.hpp` to define only data types, notably adding `GlobalUniformObject` struct to standardize uniform buffer data for shaders.

### Vulkan Shader System Improvements

* Refactored `VulkanShader` to require a `BufferManager` for buffer operations, and implemented robust creation and destruction of global descriptor sets, pools, layouts, and uniform buffers for object shaders. This ensures proper resource allocation and cleanup. [[1]](diffhunk://#diff-11721be231726cd975f4b53abb0559b00cb65f297592d619aa1f519b48284531R3-R12) [[2]](diffhunk://#diff-11721be231726cd975f4b53abb0559b00cb65f297592d619aa1f519b48284531L47-R244) [[3]](diffhunk://#diff-cf439b906ded027f444f4ee5b7f7b19b2a3ccc5381d4c22b8db5dd0ee75c4340R4-R25) [[4]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138L21-R22)

* Added `UpdateGlobalState` method to `VulkanShader` for updating uniform buffer data, and integrated this into the rendering pipeline, enabling dynamic updates of global shader state. [[1]](diffhunk://#diff-11721be231726cd975f4b53abb0559b00cb65f297592d619aa1f519b48284531R255-R275) [[2]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138R585-R587) [[3]](diffhunk://#diff-c1832aa357d5f8c0b157ad91003e441db43527affe3524cc35007d94af5e5694L95-R99)

### Shader Code Updates

* Modified GLSL shader files to use uniform blocks for projection and view matrices and updated output variable names for consistency. The fragment shader now outputs a solid red color for testing. [[1]](diffhunk://#diff-f52bac01bd8a84678dfc76b7b1764aeb8fde4d7475a9d7869a72e3bd0266db01L4-R10) [[2]](diffhunk://#diff-ff30a33406dcad0b7a2009a7143e3e6051e6698745d8f8f217242f2fcf240a09L5-R12)

### Miscellaneous Improvements

* Added a `Resize` method to `DArray` to support dynamic array resizing with optional zeroing of new memory, facilitating descriptor set management.

* Improved Vulkan backend to properly bind descriptor sets during rendering and ensured resource cleanup and error handling in object shader lifecycle. [[1]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138L484-R492) [[2]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138L499) [[3]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138L568-R575) [[4]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138L347)

---

**References:**  
[[1]](diffhunk://#diff-cfe671ce89612bd20b400e9359720b4d24df386bf15924257688816880ca5c50R1-R41) [[2]](diffhunk://#diff-c1832aa357d5f8c0b157ad91003e441db43527affe3524cc35007d94af5e5694L6-R6) [[3]](diffhunk://#diff-91822889704061f91d0769ed5370d69eb5ef3c7ddccfd01d29b4816002ac6d0eL8-R8) [[4]](diffhunk://#diff-a8f9c3a2cbd119f6906b34db8089d260f827b3cc1f173f6c5083b6e7d3714a88L4-R12) [[5]](diffhunk://#diff-11721be231726cd975f4b53abb0559b00cb65f297592d619aa1f519b48284531R3-R12) [[6]](diffhunk://#diff-11721be231726cd975f4b53abb0559b00cb65f297592d619aa1f519b48284531L47-R244) [[7]](diffhunk://#diff-cf439b906ded027f444f4ee5b7f7b19b2a3ccc5381d4c22b8db5dd0ee75c4340R4-R25) [[8]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138L21-R22) [[9]](diffhunk://#diff-11721be231726cd975f4b53abb0559b00cb65f297592d619aa1f519b48284531R255-R275) [[10]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138R585-R587) [[11]](diffhunk://#diff-c1832aa357d5f8c0b157ad91003e441db43527affe3524cc35007d94af5e5694L95-R99) [[12]](diffhunk://#diff-f52bac01bd8a84678dfc76b7b1764aeb8fde4d7475a9d7869a72e3bd0266db01L4-R10) [[13]](diffhunk://#diff-ff30a33406dcad0b7a2009a7143e3e6051e6698745d8f8f217242f2fcf240a09L5-R12) [[14]](diffhunk://#diff-9728054287a674944ed7e0739ce4dfe256ca6cf567737b8816b2963a389e983aR53-R65) [[15]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138L484-R492) [[16]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138L499) [[17]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138L568-R575) [[18]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138L347)