### PR TITLE
Decoupling Quad Creation from Engine to Game Testbed

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -158,10 +158,24 @@ If in doubt, look at how something similar is done nearby and match it.
 
 ## Submitting a PR
 
-1. Branch off `main`
-2. One feature or fix per PR — don't bundle unrelated changes
-3. Run `make` and make sure there are no errors and no ASAN/LSAN violations
-4. Write a clear PR description: what you changed and why
+We don't give direct push access. Fork the repo, work in your fork, then open a PR back here.
+
+1. Fork the repo on GitHub and clone your fork
+2. Add the upstream remote so you can stay in sync:
+   ```bash
+   git remote add upstream https://github.com/alexbsec/FlatearthEngine.git
+   git fetch upstream
+   ```
+3. Branch off `main` in your fork using the naming convention below
+4. Do your work — one feature or fix per PR, don't bundle unrelated changes
+5. Before opening the PR, sync with upstream to avoid conflicts:
+   ```bash
+   git fetch upstream
+   git rebase upstream/main
+   ```
+6. Run `make` and make sure there are no errors and no ASAN/LSAN violations
+7. Open a PR from your fork's branch to `alexbsec/FlatearthEngine:main`
+8. Write a clear PR description: what you changed and why
 
 ### Branch naming
 

--- a/engine/src/Containers/HashMap.hpp
+++ b/engine/src/Containers/HashMap.hpp
@@ -19,19 +19,24 @@ public:
       : _memoryManager(memManager), _bucketCount(bucketCount) {
     assert(bucketCount > 0);
 
-    _ppBuckets = FeCast<FePtr<Node<HashMapEntry<T, V>>> *>(
+    _ppBuckets = FeCast<FePtr<Node<HashMapEntry<T, V>>>>(
         _memoryManager.RawAlloc(sizeof(FePtr<Node<HashMapEntry<T, V>>>) * _bucketCount,
                                 alignof(FePtr<Node<HashMapEntry<T, V>>>),
                                 memory::Tag::HashMap));
 
     for (uint64 i = 0; i < _bucketCount; i++) {
-      _ppBuckets[i] = nullptr;
+      new (&_ppBuckets[i]) FePtr<Node<HashMapEntry<T, V>>>();
     }
   }
 
   ~HashMap() {
     if (_ppBuckets == nullptr) {
       return;
+    }
+
+    using BucketPtr = FePtr<Node<HashMapEntry<T, V>>>;
+    for (uint64 i = 0; i < _bucketCount; i++) {
+      _ppBuckets[i].~BucketPtr();
     }
 
     _memoryManager.RawFree(

--- a/engine/src/Core/Application.cc
+++ b/engine/src/Core/Application.cc
@@ -8,7 +8,6 @@
 #include "Core/Logger.hpp"
 #include "Defines.hpp"
 #include "Error.hpp"
-#include "Resources/TextureLoader.hpp"
 
 namespace flatearth {
 
@@ -20,7 +19,6 @@ Engine::Engine(Game *pGame)
 }
 
 Engine::~Engine() {
-  auto _ = _frontendRenderer.DestroyTexture(&_appState.testTexture);
   FLOG_INFO("engine shutdown gracefully");
 }
 
@@ -72,17 +70,19 @@ FeExpect<void, Error> Engine::Initialize() {
     return FeErr{frontendInitRes.error()};
   }
 
-  auto texRes = resources::LoadTexture(
-      "assets/textures/texture.jpg", _filesystem, _frontendRenderer, &_appState.testTexture);
-  if (!texRes.has_value()) {
-      FLOG_ERROR("failed to load texture: {}", texRes.error().message);
-      return FeErr{texRes.error()};
-  }
-
   _appState.isRunning = FeTrue;
   _appState.isSuspended = FeFalse;
   _appState.platformState = _pPlatform->State();
   _appState.pGameInstance->pInputManager = &_inputManager;
+  _appState.pGameInstance->pRenderer = &_frontendRenderer;
+
+  if (_appState.pGameInstance->Load) {
+    if (!_appState.pGameInstance->Load(_appState.pGameInstance)) {
+      FLOG_FATAL("game failed to load resources");
+      return FeErr{Error("game Load() failed", ErrorType::GameInitializeError)};
+    }
+  }
+
   FLOG_INFO("engine successfully initialized");
   return {};
 }
@@ -124,13 +124,13 @@ FeExpect<void, Error> Engine::Start() {
 
     // Hardcoded just to make it up and running
     // TODO: remove
-    renderer::RenderPacket packet;
+    renderer::RenderPacket packet(_memoryManager);
     packet.deltaTime = deltaTime;
     if (!_appState.pGameInstance->Render(_appState.pGameInstance, packet)) {
       FLOG_FATAL("could not populate render packet inside game instance");
       break;
     }
-    _frontendRenderer.SetView(packet.view);
+
     auto drawRes = _frontendRenderer.DrawFrame(&packet);
     if (!drawRes.has_value()) {
       FLOG_ERROR("frontend renderer failed to draw frame: {}", drawRes.error().message);

--- a/engine/src/Core/ApplicationConfig.hpp
+++ b/engine/src/Core/ApplicationConfig.hpp
@@ -5,7 +5,6 @@
 #include "Defines.hpp"
 #include "GameTypes.hpp"
 #include "Platform/Platform.hpp"
-#include "Resources/ResourceTypes.hpp"
 
 namespace flatearth {
 
@@ -27,9 +26,6 @@ struct ApplicationState {
   platform::PlatformState *platformState;
   ApplicationConfig appConfig;
   clock::Clock clock;
-
-  // TODO: remove, only here to store the test texture
-  resources::Texture testTexture;
 
   ApplicationState(Game *game) : pGameInstance(game) {}
 };

--- a/engine/src/Core/FeMemory.hpp
+++ b/engine/src/Core/FeMemory.hpp
@@ -49,10 +49,10 @@ public:
   MemoryManager();
   ~MemoryManager();
 
-  void *RawAlloc(uint64 size, uint64 alignment, Tag tag);
-  void RawFree(void *block, uint64 size, Tag tag);
-  void FZeroMemory(void *block, uint64 size);
-  void CopyMemory(void *dst, const void *src, uint64 size);
+  FEAPI void *RawAlloc(uint64 size, uint64 alignment, Tag tag);
+  FEAPI void RawFree(void *block, uint64 size, Tag tag);
+  FEAPI void FZeroMemory(void *block, uint64 size);
+  FEAPI void CopyMemory(void *dst, const void *src, uint64 size);
 
   template <typename T, typename... Args>
   inline FePtr<T> Allocate(Tag tag, Args &&...args) {

--- a/engine/src/GameTypes.hpp
+++ b/engine/src/GameTypes.hpp
@@ -7,6 +7,8 @@
 #include <Core/Input.hpp>
 #include <functional>
 
+namespace flatearth::renderer { class FrontendRenderer; }
+
 namespace flatearth {
 
 static constexpr int16 scDefaultStartWidth = 1080;
@@ -16,23 +18,27 @@ const string cGameName = "Flatearth Engine Demo";
 struct Game {
 public:
   std::function<bool(struct Game *gameInstance)> Initialize;
+  std::function<bool(struct Game *gameInstance)> Load;
   std::function<bool(struct Game *gameInstance, float32 deltaTime)> Update;
   std::function<bool(struct Game *gameInstance, renderer::RenderPacket &packet)> Render;
   std::function<bool(struct Game *gameInstance, uint32 width, uint32 height)> OnResize;
 
   Game()
-      : Initialize(nullptr), Update(nullptr), Render(nullptr), OnResize(nullptr),
+      : Initialize(nullptr), Load(nullptr), Update(nullptr), Render(nullptr), OnResize(nullptr),
         gameName(cGameName), windowStartWidth(scDefaultStartWidth),
         windowStartHeight(scDefaultStartHeight) {}
 
   Game(const string &name)
-      : Initialize(nullptr), Update(nullptr), Render(nullptr), OnResize(nullptr), gameName(name),
-        windowStartWidth(scDefaultStartWidth), windowStartHeight(scDefaultStartHeight) {}
+      : Initialize(nullptr), Load(nullptr), Update(nullptr), Render(nullptr), OnResize(nullptr),
+        gameName(name), windowStartWidth(scDefaultStartWidth),
+        windowStartHeight(scDefaultStartHeight) {}
 
 public:
   string gameName;
   int32 windowStartPosX, windowStartPosY, windowStartWidth, windowStartHeight;
   input::InputManager *pInputManager{nullptr};
+  // TODO: remove once resource manager exists
+  renderer::FrontendRenderer *pRenderer{nullptr};
 };
 
 } // namespace flatearth

--- a/engine/src/Renderer/RendererFrontend.cc
+++ b/engine/src/Renderer/RendererFrontend.cc
@@ -7,6 +7,8 @@
 #include "Platform/Filesystem.hpp"
 #include "Renderer/RendererInterface.hpp"
 #include "Renderer/Vulkan/VulkanBackend.hpp"
+#include "Resources/ResourceTypes.hpp"
+#include "Resources/TextureLoader.hpp"
 
 namespace flatearth::renderer {
 
@@ -46,7 +48,6 @@ FeExpect<bool, Error> FrontendRenderer::Initialize() {
   float32 aspect = static_cast<float32>(_pAppState->width) / _pAppState->height;
   _rendererState.projection = math::Mat4D::Orthographic(
       -aspect, aspect, -1.0f, 1.0f, _rendererState.nearClip, _rendererState.farClip);
-  _rendererState.view = math::Mat4D::Identity();
 
   FLOG_INFO("frontend renderer successfully initialized");
   return FeTrue;
@@ -99,17 +100,16 @@ FeExpect<bool, Error> FrontendRenderer::DrawFrame(RenderPacket *pRenderPacket) {
     return FeTrue;
   }
 
-  static float32 angle = 0.0f;
-  // radians per second (tweak speed)
-  angle += pRenderPacket->deltaTime * 1.5f;
-
-  math::Mat4D model = math::Mat4D::RotationZ(angle) * math::Mat4D::Translation(0.0f, 0.0f, 0.0f);
-  _rendererState.pActiveBackend->UpdateObject(model);
   auto updateRes = _rendererState.pActiveBackend->UpdateGlobalState(
-      _rendererState.projection, _rendererState.view, math::Vec3D::Zero(), 0);
+      _rendererState.projection, pRenderPacket->view, math::Vec3D::Zero(), 0);
   if (!updateRes.has_value()) {
     FLOG_ERROR("failed to update global state on frontend renderer");
     return FeErr{updateRes.error()};
+  }
+
+  for (uint32 i = 0; i < pRenderPacket->objects.Length(); i++) {
+    const RenderObject &object = pRenderPacket->objects[i];
+    _rendererState.pActiveBackend->DrawGeometry(object.geometryId, object.model);
   }
 
   auto endRes = EndFrame(pRenderPacket->deltaTime);
@@ -152,13 +152,26 @@ FeExpect<void, Error> FrontendRenderer::CreateTexture(const string &name,
       name, autoRelease, width, height, channelCount, pPixels, hasTransparency, pTexture);
 }
 
+FeExpect<void, Error> FrontendRenderer::CreateGeometry(uint32 id,
+                                                       uint32 vertexCount,
+                                                       const math::Vertex3D *pVertices,
+                                                       uint32 indexCount,
+                                                       const uint32 *pIndices) {
+  return _rendererState.pActiveBackend->CreateGeometry(
+      id, vertexCount, pVertices, indexCount, pIndices);
+}
+
+FeExpect<void, Error> FrontendRenderer::DestroyGeometry(uint32 id) {
+  return _rendererState.pActiveBackend->DestroyGeometry(id);
+}
+
+FeExpect<void, Error> FrontendRenderer::LoadTextureFromFile(const string &path, resources::Texture *pOut) {
+  return resources::LoadTexture(path, _filesystem, *this, pOut);
+}
+
 FeExpect<void, Error> FrontendRenderer::DestroyTexture(resources::Texture *pTexture) {
   uint32 vulkanIndex = static_cast<uint32>(BackendType::Vulkan);
   return _pBackends[vulkanIndex]->DestroyTexture(pTexture);
-}
-
-void FrontendRenderer::SetView(const math::Mat4D &view) {
-  _rendererState.view = view;
 }
 
 FeExpect<void, Error> FrontendRenderer::MakeBackends() {

--- a/engine/src/Renderer/RendererFrontend.hpp
+++ b/engine/src/Renderer/RendererFrontend.hpp
@@ -38,10 +38,13 @@ public:
                                       resources::Texture *pTexture);
   FeExpect<void, Error> DestroyTexture(resources::Texture *pTexture);
 
-  // Setters
-  // NOTE: this should not be exposed outside of the engine
-  // remove once done testing
-  FEAPI void SetView(const math::Mat4D &view);
+  FeExpect<void, Error> CreateGeometry(uint32 id,
+                                       uint32 vertexCount,
+                                       const math::Vertex3D *pVertices,
+                                       uint32 indexCount,
+                                       const uint32 *pIndices);
+  FeExpect<void, Error> DestroyGeometry(uint32 id);
+  FeExpect<void, Error> LoadTextureFromFile(const string &path, resources::Texture *pOut);
 
 private:
   FeExpect<void, Error> MakeBackends();

--- a/engine/src/Renderer/RendererFrontend.hpp
+++ b/engine/src/Renderer/RendererFrontend.hpp
@@ -38,13 +38,13 @@ public:
                                       resources::Texture *pTexture);
   FeExpect<void, Error> DestroyTexture(resources::Texture *pTexture);
 
-  FeExpect<void, Error> CreateGeometry(uint32 id,
-                                       uint32 vertexCount,
-                                       const math::Vertex3D *pVertices,
-                                       uint32 indexCount,
-                                       const uint32 *pIndices);
-  FeExpect<void, Error> DestroyGeometry(uint32 id);
-  FeExpect<void, Error> LoadTextureFromFile(const string &path, resources::Texture *pOut);
+  FEAPI FeExpect<void, Error> CreateGeometry(uint32 id,
+                                             uint32 vertexCount,
+                                             const math::Vertex3D *pVertices,
+                                             uint32 indexCount,
+                                             const uint32 *pIndices);
+  FEAPI FeExpect<void, Error> DestroyGeometry(uint32 id);
+  FEAPI FeExpect<void, Error> LoadTextureFromFile(const string &path, resources::Texture *pOut);
 
 private:
   FeExpect<void, Error> MakeBackends();

--- a/engine/src/Renderer/RendererInterface.hpp
+++ b/engine/src/Renderer/RendererInterface.hpp
@@ -3,6 +3,7 @@
 
 #include "Core/ApplicationConfig.hpp"
 #include "Defines.hpp"
+#include "Math/MathTypes.hpp"
 #include "Renderer/RendererTypes.hpp"
 #include "Resources/ResourceTypes.hpp"
 
@@ -23,7 +24,6 @@ public:
   virtual FeExpect<bool, Error> OnResize(uint32 width, uint32 height) = 0;
   virtual FeExpect<bool, Error> BeginFrame(float32 deltaTime) = 0;
   virtual FeExpect<bool, Error> EndFrame(float32 deltaTime) = 0;
-  virtual FeExpect<bool, Error> DrawFrame(const RenderPacket &renderPacket) = 0;
   virtual FeExpect<void, Error> UpdateGlobalState(math::Mat4D projection,
                                                   math::Mat4D view,
                                                   math::Vec3D viewPosition,
@@ -38,7 +38,13 @@ public:
                                               resources::Texture *pTexture) = 0;
   virtual FeExpect<void, Error> DestroyTexture(resources::Texture *pTexture) = 0;
 
-  virtual void UpdateObject(math::Mat4D model) = 0;
+  virtual FeExpect<void, Error> CreateGeometry(uint32 id,
+                                               uint32 vertexCount,
+                                               const math::Vertex3D *pVertices,
+                                               uint32 indexCount,
+                                               const uint32 *pIndices) = 0;
+  virtual FeExpect<void, Error> DestroyGeometry(uint32 id) = 0;
+  virtual void DrawGeometry(uint32 id, math::Mat4D model) = 0;
 
 protected:
   virtual ~IRendererBackend() = default;

--- a/engine/src/Renderer/RendererTypes.hpp
+++ b/engine/src/Renderer/RendererTypes.hpp
@@ -1,13 +1,23 @@
 #ifndef _FLATEARHT_ENGINE_RENDERER_TYPES_HPP
 #define _FLATEARHT_ENGINE_RENDERER_TYPES_HPP
 
+#include "Containers/DArray.hpp"
 #include "Math/Matrix4D.hpp"
 
 namespace flatearth::renderer {
 
+struct RenderObject {
+  uint32 geometryId;
+  math::Mat4D model;
+};
+
 struct RenderPacket {
   float32 deltaTime;
   math::Mat4D view;
+  containers::DArray<RenderObject> objects;
+
+  RenderPacket(memory::MemoryManager &memManager)
+    : objects(memManager) {}
 };
 
 struct GlobalUniformObject {

--- a/engine/src/Renderer/Vulkan/VulkanBackend.cc
+++ b/engine/src/Renderer/Vulkan/VulkanBackend.cc
@@ -24,7 +24,7 @@ VulkanBackend::VulkanBackend(memory::MemoryManager &memManager, platform::FileSy
     : _memoryManager(memManager), _deviceManager(memManager),
       _swapchainManager(memManager, _imageManager), _renderpassManager(memManager),
       _cmdBufferManager(memManager), _bufferManager(_cmdBufferManager),
-      _vulkanShader(memManager, _bufferManager), _ctx(memManager, fs) {
+      _vulkanShader(memManager, _bufferManager), _ctx(memManager, fs), _geometries(memManager) {
 }
 
 VulkanBackend::~VulkanBackend() {
@@ -334,54 +334,6 @@ FeExpect<bool, Error> VulkanBackend::Initialize(ApplicationState *appState) {
     return FeErr{createBufferRes.error()};
   }
 
-  // TEMPORARY TEST CODEBack
-  const uint32 cVertCount = 4;
-  std::array<math::Vertex3D, cVertCount> vertices;
-  _memoryManager.FZeroMemory(vertices.data(), sizeof(math::Vertex3D) * cVertCount);
-
-  vertices[0].position = math::Vec3D(-0.5f, -0.5f, 0.0f);
-  vertices[1].position = math::Vec3D(0.5f, 0.5f, 0.0f);
-  vertices[2].position = math::Vec3D(-0.5f, 0.5f, 0.0f);
-  vertices[3].position = math::Vec3D(0.5f, -0.5f, 0.0f);
-
-  vertices[0].uv = math::Vec2D::Zero();
-  vertices[1].uv = math::Vec2D::Right();
-  vertices[2].uv = math::Vec2D::One();
-  vertices[3].uv = math::Vec2D::Up();
-
-  const uint32 cIndexCount = 6;
-  std::array<uint32, cIndexCount> indicies = {0, 2, 1, 0, 3, 1};
-
-  VkFence tempFence;
-  VkFenceCreateInfo fenceInfo = {VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
-  vkCreateFence(_ctx.device.logicalDevice, &fenceInfo, _ctx.pAllocator, &tempFence);
-
-  auto uploadRes = UploadDataRange(_ctx.device.graphicsCommandPool,
-                                   tempFence,
-                                   _ctx.device.graphicsQueue,
-                                   0,
-                                   sizeof(math::Vertex3D) * cVertCount,
-                                   _ctx.objectVertexBuffer,
-                                   vertices.data());
-  if (!uploadRes.has_value()) {
-    FLOG_ERROR("failed to upload data range in test");
-    return FeErr{uploadRes.error()};
-  }
-
-  uploadRes = UploadDataRange(_ctx.device.graphicsCommandPool,
-                              tempFence,
-                              _ctx.device.graphicsQueue,
-                              0,
-                              sizeof(uint32) * cIndexCount,
-                              _ctx.objectIndexBuffer,
-                              indicies.data());
-
-  vkDestroyFence(_ctx.device.logicalDevice, tempFence, _ctx.pAllocator);
-  if (!uploadRes.has_value()) {
-    FLOG_ERROR("failed to upload index data");
-    return FeErr{uploadRes.error()};
-  }
-
   FLOG_INFO("sync objects & fences created successfully");
   FLOG_INFO("Vulkan backend initialized successfully");
   return FeTrue;
@@ -536,27 +488,6 @@ FeExpect<bool, Error> VulkanBackend::EndFrame(float32 deltaTime) {
     return FeErr{presentRes.error()};
   }
 
-  return FeTrue;
-}
-
-FeExpect<bool, Error> VulkanBackend::DrawFrame(const RenderPacket &renderPacket) {
-  if (_ctx.recreatingSwapchain) {
-    return FeFalse;
-  }
-
-  (void)renderPacket;
-
-  CommandBuffer &cmdBuffer = _ctx.graphicsCommandBuffer[_ctx.imageIndex];
-
-  _vulkanShader.UseShader(_ctx, _ctx.objectShader);
-
-  VkDeviceSize offset = 0;
-  vkCmdBindVertexBuffers(cmdBuffer.handle, 0, 1, &_ctx.objectVertexBuffer.handle, &offset);
-
-  vkCmdBindIndexBuffer(cmdBuffer.handle, _ctx.objectIndexBuffer.handle, 0, VK_INDEX_TYPE_UINT32);
-
-  // Draw quad (6 indices)
-  vkCmdDrawIndexed(cmdBuffer.handle, 6, 1, 0, 0, 0);
   return FeTrue;
 }
 
@@ -725,10 +656,69 @@ FeExpect<void, Error> VulkanBackend::DestroyTexture(resources::Texture *pTexture
   return {};
 }
 
-void VulkanBackend::UpdateObject(math::Mat4D model) {
+FeExpect<void, Error> VulkanBackend::CreateGeometry(uint32 id,
+                                                    uint32 vertexCount,
+                                                    const math::Vertex3D *pVertices,
+                                                    uint32 indexCount,
+                                                    const uint32 *pIndices) {
+  VkFence tempFence;
+  VkFenceCreateInfo fenceInfo = {VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
+  vkCreateFence(_ctx.device.logicalDevice, &fenceInfo, _ctx.pAllocator, &tempFence);
+
+  uint64 vertexOffset = _ctx.geometryVertexOffset;
+  uint64 indexOffset = _ctx.geometryIndexOffset;
+  uint64 vertexSize = sizeof(math::Vertex3D) * vertexCount;
+  uint64 indexSize = sizeof(uint32) * indexCount;
+
+  auto uploadRes = UploadDataRange(_ctx.device.graphicsCommandPool,
+                                   tempFence,
+                                   _ctx.device.graphicsQueue,
+                                   vertexOffset,
+                                   vertexSize,
+                                   _ctx.objectVertexBuffer,
+                                   pVertices);
+  if (!uploadRes.has_value()) {
+    vkDestroyFence(_ctx.device.logicalDevice, tempFence, _ctx.pAllocator);
+    FLOG_ERROR("failed to upload data range in test");
+    return FeErr{uploadRes.error()};
+  }
+
+  uploadRes = UploadDataRange(_ctx.device.graphicsCommandPool,
+                              tempFence,
+                              _ctx.device.graphicsQueue,
+                              indexOffset,
+                              indexSize,
+                              _ctx.objectIndexBuffer,
+                              pIndices);
+
+  vkDestroyFence(_ctx.device.logicalDevice, tempFence, _ctx.pAllocator);
+  if (!uploadRes.has_value()) {
+    FLOG_ERROR("failed to upload index data");
+    return FeErr{uploadRes.error()};
+  }
+
+  GeometryData geom{};
+  geom.vertexBufferOffset = vertexOffset;
+  geom.indexBufferOffset = indexOffset;
+  geom.indexCount = indexCount;
+  auto insertRes = _geometries.Insert(id, geom);
+  if (!insertRes.has_value()) {
+    FLOG_ERROR("failed to insert geometry into hashmap");
+    return FeErr{insertRes.error()};
+  }
+
+  _ctx.geometryIndexOffset += indexSize;
+  _ctx.geometryVertexOffset += vertexSize;
+  return {};
+}
+
+FeExpect<void, Error> VulkanBackend::DestroyGeometry(uint32 id) {
+  return {};
+}
+
+void VulkanBackend::DrawGeometry(uint32 id, math::Mat4D model) {
   CommandBuffer &cmdBuffer = _ctx.graphicsCommandBuffer[_ctx.imageIndex];
   _vulkanShader.UpdateObject(_ctx, _ctx.objectShader, model.ToGPUMatrix());
-
   _vulkanShader.UseShader(_ctx, _ctx.objectShader);
 
   {
@@ -772,8 +762,13 @@ void VulkanBackend::UpdateObject(math::Mat4D model) {
   constexpr uint32 cFirstScissor = 0;
   constexpr uint32 cScissorCount = 1;
 
-  // TODO: remove (for tests)
-  std::array<VkDeviceSize, 1> offsets = {0};
+  const GeometryData *pGeom = _geometries.Retrieve(id);
+  if (pGeom == nullptr) {
+    FLOG_WARN("failed to retrieve unexistent geometry for id {}", id);
+    return;
+  }
+
+  std::array<VkDeviceSize, 1> offsets = {pGeom->vertexBufferOffset};
 
   vkCmdSetViewport(cmdBuffer.handle, cFirstViewport, cViewportCount, &viewport);
   vkCmdSetScissor(cmdBuffer.handle, cFirstScissor, cScissorCount, &scissor);
@@ -784,9 +779,12 @@ void VulkanBackend::UpdateObject(math::Mat4D model) {
                          &_ctx.objectVertexBuffer.handle,
                          static_cast<VkDeviceSize *>(offsets.data()));
 
-  vkCmdBindIndexBuffer(cmdBuffer.handle, _ctx.objectIndexBuffer.handle, 0, VK_INDEX_TYPE_UINT32);
+  vkCmdBindIndexBuffer(cmdBuffer.handle,
+                       _ctx.objectIndexBuffer.handle,
+                       pGeom->indexBufferOffset,
+                       VK_INDEX_TYPE_UINT32);
 
-  vkCmdDrawIndexed(cmdBuffer.handle, 6, 1, 0, 0, 0);
+  vkCmdDrawIndexed(cmdBuffer.handle, pGeom->indexCount, 1, 0, 0, 0);
 }
 
 // PRIVATE MEMBERS
@@ -919,7 +917,7 @@ FeExpect<void, Error> VulkanBackend::UploadDataRange(VkCommandPool pool,
                                                      uint64 offset,
                                                      uint64 size,
                                                      VulkanBuffer &buffer,
-                                                     void *pData) {
+                                                     const void *pData) {
   VkBufferUsageFlags usageFlags = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
   VkMemoryPropertyFlags memoryFlags =
       VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;

--- a/engine/src/Renderer/Vulkan/VulkanBackend.hpp
+++ b/engine/src/Renderer/Vulkan/VulkanBackend.hpp
@@ -4,8 +4,8 @@
 #include "Core/ApplicationConfig.hpp"
 #include "Core/FeMemory.hpp"
 #include "Platform/Filesystem.hpp"
+#include "Containers/HashMap.hpp"
 #include "Renderer/RendererInterface.hpp"
-#include "Renderer/RendererTypes.hpp"
 #include "Renderer/Vulkan/Shaders/ObjectShader.hpp"
 #include "Renderer/Vulkan/VulkanBuffer.hpp"
 #include "Renderer/Vulkan/VulkanCommandBufferManager.hpp"
@@ -13,6 +13,7 @@
 #include "Renderer/Vulkan/VulkanImager.hpp"
 #include "Renderer/Vulkan/VulkanRenderpassManager.hpp"
 #include "Renderer/Vulkan/VulkanSwapchainManager.hpp"
+#include "Renderer/Vulkan/VulkanTypes.hpp"
 
 namespace flatearth::renderer::vulkan {
 
@@ -25,7 +26,6 @@ public:
   FeExpect<bool, Error> OnResize(uint32 width, uint32 height) override;
   FeExpect<bool, Error> BeginFrame(float32 deltaTime) override;
   FeExpect<bool, Error> EndFrame(float32 deltaTime) override;
-  FeExpect<bool, Error> DrawFrame(const RenderPacket &renderPacket) override;
   FeExpect<void, Error> UpdateGlobalState(math::Mat4D projection,
                                           math::Mat4D view,
                                           math::Vec3D viewPosition,
@@ -40,8 +40,14 @@ public:
                                       bool hasTransparency,
                                       resources::Texture *pTexture) override;
   FeExpect<void, Error> DestroyTexture(resources::Texture *pTexture) override;
+  FeExpect<void, Error> CreateGeometry(uint32 id,
+                                       uint32 vertexCount,
+                                       const math::Vertex3D *pVertices,
+                                       uint32 indexCount,
+                                       const uint32 *pIndices) override;
+  FeExpect<void, Error> DestroyGeometry(uint32 id) override;
 
-  void UpdateObject(math::Mat4D model) override;
+  void DrawGeometry(uint32 id, math::Mat4D model) override;
 
 private:
   FeExpect<void, Error> CreateFence(Fence *pFence, bool signaled);
@@ -55,7 +61,7 @@ private:
                                         uint64 offset,
                                         uint64 size,
                                         VulkanBuffer &buffer,
-                                        void *pData);
+                                        const void *pData);
 
   void TextureSubmitCallback(CommandBuffer cmd,
                              VkFormat imageFormat,
@@ -73,6 +79,8 @@ private:
   shaders::VulkanShader _vulkanShader;
   // No-op (not an error)
   Context _ctx;
+
+  containers::HashMap<uint32, GeometryData> _geometries;
 
   uint32 _cachedFrameBufferWidth{0}, _cachedFrameBufferHeight{0};
 };

--- a/engine/src/Renderer/Vulkan/VulkanTypes.hpp
+++ b/engine/src/Renderer/Vulkan/VulkanTypes.hpp
@@ -75,6 +75,13 @@ inline bool VkResultIsSuccess(VkResult result) {
   }
 }
 
+struct GeometryData {
+  uint64 vertexBufferOffset{0};
+  uint64 indexBufferOffset{0};
+  uint32 indexCount{0};
+  uint32 vertexCount{0};
+};
+
 struct VulkanBuffer {
   uint32 totalSize;
   VkBuffer handle;

--- a/testbed/src/Entrypoint.cc
+++ b/testbed/src/Entrypoint.cc
@@ -8,10 +8,11 @@
 
 bool CreateGame(flatearth::Game *pGame) {
   using namespace flatearth::testbed;
-  pGame->Update = GameTest::GameUpdate;
   pGame->Initialize = GameTest::GameInitialize;
-  pGame->OnResize = GameTest::GameOnResize;
+  pGame->Load = GameTest::GameLoad;
+  pGame->Update = GameTest::GameUpdate;
   pGame->Render = GameTest::GameRender;
+  pGame->OnResize = GameTest::GameOnResize;
   return true;
 }
 

--- a/testbed/src/Game.cc
+++ b/testbed/src/Game.cc
@@ -4,6 +4,7 @@
 #include <Core/Logger.hpp>
 #include <Defines.hpp>
 #include <Math/FeMath.hpp>
+#include <Renderer/RendererFrontend.hpp>
 #include <Renderer/RendererTypes.hpp>
 
 namespace flatearth::testbed {
@@ -30,6 +31,37 @@ bool GameTest::GameInitialize(flatearth::Game *gameInstance) {
   _state.cameraEuler = math::Vec3D::Zero();
   _state.view = math::Mat4D::Identity();
   _state.cameraViewDirty = FeTrue;
+  return FeTrue;
+}
+
+bool GameTest::GameLoad(flatearth::Game *gameInstance) {
+  std::array<math::Vertex3D, 4> verts{};
+  verts[0].position = math::Vec3D(-0.5f, -0.5f, 0.0f);
+  verts[1].position = math::Vec3D(0.5f,  0.5f,  0.0f);
+  verts[2].position = math::Vec3D(-0.5f, 0.5f,  0.0f);
+  verts[3].position = math::Vec3D(0.5f,  -0.5f, 0.0f);
+
+  verts[0].uv = math::Vec2D::Zero();
+  verts[1].uv = math::Vec2D::Right();
+  verts[2].uv = math::Vec2D::One();
+  verts[3].uv = math::Vec2D::Up();
+
+  std::array<uint32, 6> indices = {0, 2, 1, 0, 3, 1};
+
+  auto geomRes = gameInstance->pRenderer->CreateGeometry(
+      _state.quadGeometry, 4, verts.data(), 6, indices.data());
+  if (!geomRes.has_value()) {
+    FLOG_ERROR("failed to create quad geometry");
+    return FeFalse;
+  }
+
+  auto texRes = gameInstance->pRenderer->LoadTextureFromFile(
+      "assets/textures/texture.jpg", &_state.texture);
+  if (!texRes.has_value()) {
+    FLOG_ERROR("failed to load texture");
+    return FeFalse;
+  }
+
   return FeTrue;
 }
 
@@ -67,6 +99,11 @@ bool GameTest::GameUpdate(flatearth::Game *gameInstance, float32 deltaTime) {
 bool GameTest::GameRender(flatearth::Game *, renderer::RenderPacket &packet) {
   RecalculateCameraView(_state);
   packet.view = _state.view;
+
+  _state.angle += packet.deltaTime * 1.5f;
+  math::Mat4D model = math::Mat4D::RotationZ(_state.angle);
+  packet.objects.Push({_state.quadGeometry, model});
+
   return FeTrue;
 }
 

--- a/testbed/src/Game.cc
+++ b/testbed/src/Game.cc
@@ -55,6 +55,13 @@ bool GameTest::GameLoad(flatearth::Game *gameInstance) {
     return FeFalse;
   }
 
+  geomRes = gameInstance->pRenderer->CreateGeometry(
+      _state.quad2Geometry, 4, verts.data(), 6, indices.data());
+  if (!geomRes.has_value()) {
+    FLOG_ERROR("failed to create second quad geometry");
+    return FeFalse;
+  }
+
   auto texRes = gameInstance->pRenderer->LoadTextureFromFile(
       "assets/textures/texture.jpg", &_state.texture);
   if (!texRes.has_value()) {
@@ -103,6 +110,10 @@ bool GameTest::GameRender(flatearth::Game *, renderer::RenderPacket &packet) {
   _state.angle += packet.deltaTime * 1.5f;
   math::Mat4D model = math::Mat4D::RotationZ(_state.angle);
   packet.objects.Push({_state.quadGeometry, model});
+
+  _state.angle2 -= packet.deltaTime * 2.0f;
+  math::Mat4D model2 = math::Mat4D::Translation(0.0f, 1.2f, 0.0f) * math::Mat4D::RotationZ(_state.angle2);
+  packet.objects.Push({_state.quad2Geometry, model2});
 
   return FeTrue;
 }

--- a/testbed/src/Game.hpp
+++ b/testbed/src/Game.hpp
@@ -16,8 +16,10 @@ struct GameState {
   bool cameraViewDirty{false};
 
   uint32 quadGeometry{0};
+  uint32 quad2Geometry{1};
   resources::Texture texture;
   float32 angle{0.0f};
+  float32 angle2{0.0f};
 };
 
 class GameTest {

--- a/testbed/src/Game.hpp
+++ b/testbed/src/Game.hpp
@@ -5,6 +5,7 @@
 #include <GameTypes.hpp>
 #include <Math/Matrix4D.hpp>
 #include <Renderer/RendererTypes.hpp>
+#include <Resources/ResourceTypes.hpp>
 
 namespace flatearth::testbed {
 
@@ -13,11 +14,16 @@ struct GameState {
   math::Mat4D view;
   math::Vec3D cameraPosition, cameraEuler;
   bool cameraViewDirty{false};
+
+  uint32 quadGeometry{0};
+  resources::Texture texture;
+  float32 angle{0.0f};
 };
 
 class GameTest {
 public:
   static bool GameInitialize(flatearth::Game *gameInstance);
+  static bool GameLoad(flatearth::Game *gameInstance);
   static bool GameUpdate(flatearth::Game *gameInstance, float32 deltaTime);
   static bool GameRender(flatearth::Game *gameInstance, renderer::RenderPacket &packet);
   static bool GameOnResize(flatearth::Game *gameInstance, uint32 width, uint32 height);


### PR DESCRIPTION
This pull request introduces a significant refactor to the rendering pipeline, focusing on removing hardcoded test code, introducing a flexible geometry system, and improving the game/application interface. The changes enable the engine to support multiple renderable objects, allow games to manage their own resource loading, and clean up various temporary or test-only code paths.

**Rendering System Refactor and Geometry Management:**

* Added a flexible geometry system: introduced `RenderObject` and updated `RenderPacket` to support multiple objects; implemented `CreateGeometry`, `DestroyGeometry`, and `DrawGeometry` methods in `FrontendRenderer` and `IRendererBackend`, with Vulkan backend support. This replaces hardcoded geometry and prepares for dynamic scene rendering. [[1]](diffhunk://#diff-a8f9c3a2cbd119f6906b34db8089d260f827b3cc1f173f6c5083b6e7d3714a88R4-R20) [[2]](diffhunk://#diff-c1832aa357d5f8c0b157ad91003e441db43527affe3524cc35007d94af5e5694R155-L163) [[3]](diffhunk://#diff-cfe671ce89612bd20b400e9359720b4d24df386bf15924257688816880ca5c50L41-R47) [[4]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138L728-L731)
* Removed hardcoded test geometry upload and draw code from the Vulkan backend, making the renderer ready for real game-driven geometry. [[1]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138L337-L384) [[2]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138L542-L562)

**Game/Engine Interface Improvements:**

* Added a `Load` callback to the `Game` struct for resource loading, and provided the renderer instance to the game, allowing games to load resources themselves rather than relying on engine test code. [[1]](diffhunk://#diff-8d7039d912d0ae2089cb95e7bacb535d24b4d3630b56eb04cb54feb96420e476R21-R41) [[2]](diffhunk://#diff-06014678d18a220dac3c5e4ccb0d7395acf7ff5ef6f1e2e4f4618bc91a8fc07dL75-R85)
* Removed the test texture from `ApplicationState` and all related test texture loading/cleanup code, further decoupling engine from test/demo resources. [[1]](diffhunk://#diff-cf95a0b4f702a5339ab30c4f66028dd6b9eb1fbb81aac45fdd4d3b7f0f4d7897L31-L33) [[2]](diffhunk://#diff-06014678d18a220dac3c5e4ccb0d7395acf7ff5ef6f1e2e4f4618bc91a8fc07dL23) [[3]](diffhunk://#diff-06014678d18a220dac3c5e4ccb0d7395acf7ff5ef6f1e2e4f4618bc91a8fc07dL11)

**HashMap and Memory Management:**

* Improved `HashMap` construction and destruction for better memory safety by using placement new for bucket initialization and explicit destructor calls. [[1]](diffhunk://#diff-68908730b66432b56fd3f29a898ce7bb175b04e810d63d951563a9b8d9903241L22-R28) [[2]](diffhunk://#diff-68908730b66432b56fd3f29a898ce7bb175b04e810d63d951563a9b8d9903241R37-R41)

**Renderer API and Codebase Cleanup:**

* Removed the `SetView` method and instead passed the view matrix through `RenderPacket`, clarifying data flow and reducing unnecessary API exposure. [[1]](diffhunk://#diff-c1832aa357d5f8c0b157ad91003e441db43527affe3524cc35007d94af5e5694L49) [[2]](diffhunk://#diff-91822889704061f91d0769ed5370d69eb5ef3c7ddccfd01d29b4816002ac6d0eL41-R47)
* Added `LoadTextureFromFile` to `FrontendRenderer` for easier resource management.

These changes collectively modernize the engine's rendering pipeline, improve separation of concerns, and lay the groundwork for scalable, game-driven rendering.