### PR TITLE
added texture filter option and plumbing

### DIFF
--- a/engine/src/Renderer/RendererFrontend.cc
+++ b/engine/src/Renderer/RendererFrontend.cc
@@ -145,10 +145,11 @@ FeExpect<void, Error> FrontendRenderer::CreateTexture(const string &name,
                                                       int32 channelCount,
                                                       const uint8 *pPixels,
                                                       bool hasTransparency,
-                                                      resources::Texture *pTexture) {
+                                                      resources::Texture *pTexture,
+                                                      resources::TextureFilter filter) {
   uint32 vulkanIndex = static_cast<uint32>(BackendType::Vulkan);
   return _pBackends[vulkanIndex]->CreateTexture(
-      name, autoRelease, width, height, channelCount, pPixels, hasTransparency, pTexture);
+      name, autoRelease, width, height, channelCount, pPixels, hasTransparency, pTexture, filter);
 }
 
 FeExpect<void, Error> FrontendRenderer::CreateGeometry(uint32 id,

--- a/engine/src/Renderer/RendererFrontend.hpp
+++ b/engine/src/Renderer/RendererFrontend.hpp
@@ -6,6 +6,7 @@
 #include "Defines.hpp"
 #include "Platform/Filesystem.hpp"
 #include "Renderer/RendererInterface.hpp"
+#include "Resources/ResourceTypes.hpp"
 
 namespace flatearth::renderer {
 
@@ -28,14 +29,16 @@ public:
   FeExpect<bool, Error> DrawFrame(RenderPacket *pRenderPacket);
   FeExpect<void, Error> OnResize(uint32 width, uint32 height);
 
-  FeExpect<void, Error> CreateTexture(const string &name,
-                                      bool autoRelease,
-                                      int32 width,
-                                      int32 height,
-                                      int32 channelCount,
-                                      const uint8 *pPixels,
-                                      bool hasTransparency,
-                                      resources::Texture *pTexture);
+  FeExpect<void, Error>
+  CreateTexture(const string &name,
+                bool autoRelease,
+                int32 width,
+                int32 height,
+                int32 channelCount,
+                const uint8 *pPixels,
+                bool hasTransparency,
+                resources::Texture *pTexture,
+                resources::TextureFilter filter = resources::TextureFilter::Nearest);
   FeExpect<void, Error> DestroyTexture(resources::Texture *pTexture);
 
   FEAPI FeExpect<void, Error> CreateMaterial(resources::Material *pMaterial,

--- a/engine/src/Renderer/RendererInterface.hpp
+++ b/engine/src/Renderer/RendererInterface.hpp
@@ -35,7 +35,8 @@ public:
                                               int32 channelCount,
                                               const uint8 *pPixels,
                                               bool hasTransparency,
-                                              resources::Texture *pTexture) = 0;
+                                              resources::Texture *pTexture,
+                                              resources::TextureFilter filter) = 0;
   virtual FeExpect<void, Error> DestroyTexture(resources::Texture *pTexture) = 0;
 
   virtual FeExpect<void, Error> CreateGeometry(uint32 id,

--- a/engine/src/Renderer/Vulkan/VulkanBackend.cc
+++ b/engine/src/Renderer/Vulkan/VulkanBackend.cc
@@ -519,7 +519,8 @@ FeExpect<void, Error> VulkanBackend::CreateTexture(const string &name,
                                                    int32 channelCount,
                                                    const uint8 *pPixels,
                                                    bool hasTransparency,
-                                                   resources::Texture *pTexture) {
+                                                   resources::Texture *pTexture,
+                                                   resources::TextureFilter filter) {
   if (pTexture == nullptr) {
     FLOG_ERROR("cannot create a texture on a nullptr");
     return FeErr{Error("failed to create texture in vulkan backend", ErrorType::NullptrException)};
@@ -529,6 +530,7 @@ FeExpect<void, Error> VulkanBackend::CreateTexture(const string &name,
   pTexture->height = height;
   pTexture->channelCount = channelCount;
   pTexture->generation = 0;
+  pTexture->filter = filter;
 
   void *pData =
       _memoryManager.RawAlloc(sizeof(TextureData), alignof(TextureData), memory::Tag::Texture);
@@ -568,7 +570,8 @@ FeExpect<void, Error> VulkanBackend::CreateTexture(const string &name,
           VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
       VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
       FeTrue,
-      VK_IMAGE_ASPECT_COLOR_BIT);
+      VK_IMAGE_ASPECT_COLOR_BIT,
+      filter);
   if (!createRes.has_value()) {
     FLOG_ERROR("failed to create image for texture");
     return FeErr{Error("texture failed to create image", ErrorType::RendererVulkanError)};
@@ -593,23 +596,7 @@ FeExpect<void, Error> VulkanBackend::CreateTexture(const string &name,
     return FeErr{Error("texture creation failed during submit", ErrorType::RendererVulkanError)};
   }
 
-  VkSamplerCreateInfo samplerInfo = {VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO};
-  samplerInfo.magFilter = VK_FILTER_LINEAR;
-  samplerInfo.minFilter = VK_FILTER_LINEAR;
-  samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-  samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-  samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-  samplerInfo.anisotropyEnable = VK_TRUE;
-  samplerInfo.maxAnisotropy = 16;
-  samplerInfo.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
-  samplerInfo.unnormalizedCoordinates = VK_FALSE;
-  samplerInfo.compareEnable = VK_FALSE;
-  samplerInfo.compareOp = VK_COMPARE_OP_ALWAYS;
-  samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-  samplerInfo.mipLodBias = 0.0f;
-  samplerInfo.minLod = 0.0f;
-  samplerInfo.maxLod = 0.0f;
-
+  VkSamplerCreateInfo samplerInfo = SamplerInfoByFilter(filter);
   VkResult result = vkCreateSampler(
       _ctx.device.logicalDevice, &samplerInfo, _ctx.pAllocator, &pTextureData->sampler);
   if (!VkResultIsSuccess(result)) {

--- a/engine/src/Renderer/Vulkan/VulkanBackend.hpp
+++ b/engine/src/Renderer/Vulkan/VulkanBackend.hpp
@@ -1,10 +1,10 @@
 #ifndef _FLATEARTH_ENGINE_RENDERER_VULKAN_BACKEND_HPP
 #define _FLATEARTH_ENGINE_RENDERER_VULKAN_BACKEND_HPP
 
+#include "Containers/HashMap.hpp"
 #include "Core/ApplicationConfig.hpp"
 #include "Core/FeMemory.hpp"
 #include "Platform/Filesystem.hpp"
-#include "Containers/HashMap.hpp"
 #include "Renderer/RendererInterface.hpp"
 #include "Renderer/Vulkan/Shaders/ObjectShader.hpp"
 #include "Renderer/Vulkan/VulkanBuffer.hpp"
@@ -14,6 +14,7 @@
 #include "Renderer/Vulkan/VulkanRenderpassManager.hpp"
 #include "Renderer/Vulkan/VulkanSwapchainManager.hpp"
 #include "Renderer/Vulkan/VulkanTypes.hpp"
+#include "Resources/ResourceTypes.hpp"
 
 namespace flatearth::renderer::vulkan {
 
@@ -38,7 +39,8 @@ public:
                                       int32 channelCount,
                                       const uint8 *pPixels,
                                       bool hasTransparency,
-                                      resources::Texture *pTexture) override;
+                                      resources::Texture *pTexture,
+                                      resources::TextureFilter filter) override;
   FeExpect<void, Error> DestroyTexture(resources::Texture *pTexture) override;
   FeExpect<void, Error> CreateGeometry(uint32 id,
                                        uint32 vertexCount,
@@ -48,7 +50,8 @@ public:
   FeExpect<void, Error> DestroyGeometry(uint32 id) override;
   void DrawGeometry(uint32 id, math::Mat4D model, const resources::Material *pMaterial) override;
 
-  FeExpect<void, Error> CreateMaterial(resources::Material *pMaterial, const resources::Texture *pTexture) override;
+  FeExpect<void, Error> CreateMaterial(resources::Material *pMaterial,
+                                       const resources::Texture *pTexture) override;
   FeExpect<void, Error> DestroyMaterial(resources::Material *pMaterial) override;
 
 private:

--- a/engine/src/Renderer/Vulkan/VulkanImager.cc
+++ b/engine/src/Renderer/Vulkan/VulkanImager.cc
@@ -1,4 +1,5 @@
 #include "VulkanImager.hpp"
+#include "Resources/ResourceTypes.hpp"
 
 #include <vulkan/vulkan_core.h>
 
@@ -14,7 +15,8 @@ FeExpect<void, Error> ImageManager::CreateImage(Context &ctx,
                                                 VkImageUsageFlags usageFlags,
                                                 VkMemoryPropertyFlags memoryFlags,
                                                 bool createView,
-                                                VkImageAspectFlags aspectFlags) {
+                                                VkImageAspectFlags aspectFlags,
+                                                resources::TextureFilter filter) {
   image.width = width;
   image.height = height;
 
@@ -22,9 +24,13 @@ FeExpect<void, Error> ImageManager::CreateImage(Context &ctx,
   imgCreateInfo.imageType = VK_IMAGE_TYPE_2D;
   imgCreateInfo.extent.width = width;
   imgCreateInfo.extent.height = height;
+  imgCreateInfo.mipLevels = 4;
+  if (filter == resources::TextureFilter::Nearest) {
+    imgCreateInfo.mipLevels = 1;
+  }
+
   // TODO: MAKE THESE CONFIGURABLE
   imgCreateInfo.extent.depth = 1;
-  imgCreateInfo.mipLevels = 4;
   imgCreateInfo.arrayLayers = 1;
   imgCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
   imgCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;

--- a/engine/src/Renderer/Vulkan/VulkanImager.hpp
+++ b/engine/src/Renderer/Vulkan/VulkanImager.hpp
@@ -3,6 +3,7 @@
 
 #include "Error.hpp"
 #include "Renderer/Vulkan/VulkanTypes.hpp"
+#include "Resources/ResourceTypes.hpp"
 
 namespace flatearth::renderer::vulkan {
 
@@ -18,7 +19,8 @@ public:
                                     VkImageUsageFlags usageFlags,
                                     VkMemoryPropertyFlags memoryFlags,
                                     bool createView,
-                                    VkImageAspectFlags aspectFlags);
+                                    VkImageAspectFlags aspectFlags,
+                                    resources::TextureFilter filter = resources::TextureFilter::Linear);
 
   FeExpect<void, Error> TransitionImageLayout(Context &ctx,
                                               CommandBuffer &cmdBuffer,

--- a/engine/src/Renderer/Vulkan/VulkanUtils.cc
+++ b/engine/src/Renderer/Vulkan/VulkanUtils.cc
@@ -2,6 +2,8 @@
 
 #include "Core/Logger.hpp"
 #include "Platform/Filesystem.hpp"
+#include "Resources/ResourceTypes.hpp"
+#include <vulkan/vulkan_core.h>
 
 namespace flatearth::renderer::vulkan {
 
@@ -98,6 +100,35 @@ FeExpect<bool, Error> CreateShaderModule(Context &ctx,
   pShaderStage[stageIndex].shaderModuleCreateInfo.pCode = nullptr;
   pShaderStage[stageIndex].shaderModuleCreateInfo.codeSize = 0;
   return FeTrue;
+}
+
+VkSamplerCreateInfo SamplerInfoByFilter(resources::TextureFilter filter) {
+  VkSamplerCreateInfo samplerInfo = {VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO};
+  samplerInfo.magFilter = VK_FILTER_LINEAR;
+  samplerInfo.minFilter = VK_FILTER_LINEAR;
+  samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+  samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+  samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+  samplerInfo.anisotropyEnable = VK_TRUE;
+  samplerInfo.maxAnisotropy = 16;
+  samplerInfo.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
+  samplerInfo.unnormalizedCoordinates = VK_FALSE;
+  samplerInfo.compareEnable = VK_FALSE;
+  samplerInfo.compareOp = VK_COMPARE_OP_ALWAYS;
+  samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+  samplerInfo.mipLodBias = 0.0f;
+  samplerInfo.minLod = 0.0f;
+  samplerInfo.maxLod = 0.0f;
+
+  if (filter == resources::TextureFilter::Nearest) {
+    samplerInfo.magFilter = VK_FILTER_NEAREST;
+    samplerInfo.minFilter = VK_FILTER_NEAREST;
+    samplerInfo.anisotropyEnable = VK_FALSE;
+    samplerInfo.maxAnisotropy = 1;
+    samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+  }
+
+  return samplerInfo;
 }
 
 } // namespace flatearth::renderer::vulkan

--- a/engine/src/Renderer/Vulkan/VulkanUtils.hpp
+++ b/engine/src/Renderer/Vulkan/VulkanUtils.hpp
@@ -15,6 +15,8 @@ FeExpect<bool, Error> CreateShaderModule(Context &ctx,
                                          uint32 stageIndex,
                                          ShaderStage *pShaderStage);
 
+VkSamplerCreateInfo SamplerInfoByFilter(resources::TextureFilter filter);
+
 } // namespace flatearth::renderer::vulkan
 
 #endif // _FLATEARTH_ENGINE_RENDERER_VULKAN_UTILS_HPP

--- a/engine/src/Resources/ResourceTypes.hpp
+++ b/engine/src/Resources/ResourceTypes.hpp
@@ -15,6 +15,11 @@ enum class MeshShape {
   Capsule2D,
 };
 
+enum class TextureFilter {
+  Nearest,
+  Linear,
+};
+
 struct Mesh {
   uint32 id;
   string name;
@@ -37,6 +42,7 @@ struct Texture {
   uint32 generation;
   uint32 channelCount;
   bool hasTransparency;
+  TextureFilter filter;
   void *pInternalData;
 };
 

--- a/engine/src/Resources/TextureSystem.cc
+++ b/engine/src/Resources/TextureSystem.cc
@@ -10,15 +10,17 @@ namespace flatearth::resources {
 TextureSystem::TextureSystem(memory::MemoryManager &memManager,
                              renderer::FrontendRenderer &renderer,
                              platform::FileSystem &fs)
-    : ResourceSystem(memManager), _renderer(renderer), _fs(fs) {}
+    : ResourceSystem(memManager), _renderer(renderer), _fs(fs) {
+}
 
-FeExpect<TextureHandle, Error> TextureSystem::AcquireTexture(const string &path) {
+FeExpect<TextureHandle, Error> TextureSystem::AcquireTexture(const string &path,
+                                                             TextureFilter filter) {
+  _filterToUse = filter;
   return this->ProtectedAcquire(path);
 }
 
-FeExpect<void, Error> TextureSystem::Create(Texture *pTexture,
-                                            uint32 /*handle*/,
-                                            const string &path) {
+FeExpect<void, Error>
+TextureSystem::Create(Texture *pTexture, uint32 /*handle*/, const string &path) {
   if (!_fs.Exists(path)) {
     FLOG_ERROR("texture file not found: {}", path);
     return FeErr{Error("texture file not found", ErrorType::FileOpenError)};
@@ -37,8 +39,7 @@ FeExpect<void, Error> TextureSystem::Create(Texture *pTexture,
   rawBytes.Resize(fileSize);
 
   auto readRes = _fs.ReadFromFile(
-      fileHandle,
-      std::span<std::byte>(reinterpret_cast<std::byte *>(rawBytes.Data()), fileSize));
+      fileHandle, std::span<std::byte>(reinterpret_cast<std::byte *>(rawBytes.Data()), fileSize));
 
   if (auto closeRes = _fs.CloseFile(fileHandle); !closeRes.has_value()) {
     FLOG_ERROR("failed to close texture file: {}", path);
@@ -60,8 +61,8 @@ FeExpect<void, Error> TextureSystem::Create(Texture *pTexture,
   }
 
   bool hasTransparency = channels == 4;
-  auto texRes =
-      _renderer.CreateTexture(path, false, width, height, 4, pPixels, hasTransparency, pTexture);
+  auto texRes = _renderer.CreateTexture(
+      path, false, width, height, 4, pPixels, hasTransparency, pTexture, _filterToUse);
 
   stbi_image_free(pPixels);
 

--- a/engine/src/Resources/TextureSystem.hpp
+++ b/engine/src/Resources/TextureSystem.hpp
@@ -15,13 +15,15 @@ public:
                                renderer::FrontendRenderer &renderer,
                                platform::FileSystem &fs);
 
-  FEAPI FeExpect<TextureHandle, Error> AcquireTexture(const string &path);
+  FEAPI FeExpect<TextureHandle, Error>
+  AcquireTexture(const string &path, TextureFilter filter = TextureFilter::Nearest);
 
 protected:
   FeExpect<void, Error> Create(Texture *pTexture, uint32 handle, const string &path) override;
   FeExpect<void, Error> Destroy(Texture *pTexture) override;
 
 private:
+  TextureFilter _filterToUse{TextureFilter::Nearest};
   renderer::FrontendRenderer &_renderer;
   platform::FileSystem &_fs;
 };


### PR DESCRIPTION
This pull request adds support for configurable texture filtering (Nearest or Linear) throughout the renderer and resource system. The main changes involve updating the texture creation pipeline to accept and propagate a `TextureFilter` parameter, and using this to control Vulkan sampler creation and mipmap levels. This allows textures to be created with either nearest-neighbor or linear filtering, improving flexibility for different rendering needs.

**Texture Filtering Support**

* Added a `TextureFilter` enum to `ResourceTypes.hpp` and a `filter` field to the `Texture` struct to store the filter type for each texture. [[1]](diffhunk://#diff-ad19afb6b444516e3761ad757d8701fa6a5124f22e3a420776f66a4c23bf0a18R18-R22) [[2]](diffhunk://#diff-ad19afb6b444516e3761ad757d8701fa6a5124f22e3a420776f66a4c23bf0a18R45)
* Updated `TextureSystem::AcquireTexture` and `TextureSystem::Create` to accept and use a `TextureFilter` parameter, storing the chosen filter and passing it through to renderer texture creation. [[1]](diffhunk://#diff-2201f968efd4969b28a73d09a4a406c0955e3e0263c9bf0446bff6b5c8602736L13-R23) [[2]](diffhunk://#diff-2201f968efd4969b28a73d09a4a406c0955e3e0263c9bf0446bff6b5c8602736L63-R65) [[3]](diffhunk://#diff-6d3fc7752b6670ab65197333f8c245e80d212d7402b49815a0378919075507f2L18-R26)
* Modified the `FrontendRenderer::CreateTexture` method and interface to accept a `TextureFilter` argument, defaulting to `Nearest` for backward compatibility. [[1]](diffhunk://#diff-c1832aa357d5f8c0b157ad91003e441db43527affe3524cc35007d94af5e5694L148-R152) [[2]](diffhunk://#diff-91822889704061f91d0769ed5370d69eb5ef3c7ddccfd01d29b4816002ac6d0eL31-R41)

**Vulkan Backend and Image Creation**

* Updated the Vulkan backend's `CreateTexture` and `ImageManager::CreateImage` methods to accept and propagate the `TextureFilter`, using it to set mipmap levels and sampler parameters. [[1]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138L522-R523) [[2]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138R533) [[3]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138L571-R574) [[4]](diffhunk://#diff-88c87426d6b3193edc57cbebec60e571276e5b6d66dae8b6afeb7f9c72694f3cL17-L27) [[5]](diffhunk://#diff-16d60416f4ad693a33283f5f425c4abf0e9cba6122fcf99bb7d725d33ab34815L21-R23)
* Implemented a new utility function `SamplerInfoByFilter` in `VulkanUtils` to generate a `VkSamplerCreateInfo` struct with the appropriate filtering and mipmapping settings based on the selected `TextureFilter`. [[1]](diffhunk://#diff-63fdbf1e782124a8f1b877953698b7f20b17138049f0870ce039fd34ba62aaa8R105-R133) [[2]](diffhunk://#diff-aab15a70db31cad94466ef8d261019d736d1eeab3fe38250b56e780fbd39563aR18-R19)

**Header and Include Cleanups**

* Added necessary includes for `ResourceTypes.hpp` in affected files to support the new `TextureFilter` type. [[1]](diffhunk://#diff-91822889704061f91d0769ed5370d69eb5ef3c7ddccfd01d29b4816002ac6d0eR9) [[2]](diffhunk://#diff-f7fd3814618b64b7d6c8dd3a65684dfe47ee4f657df5189c32cf0f7967cd3e3cR17) [[3]](diffhunk://#diff-88c87426d6b3193edc57cbebec60e571276e5b6d66dae8b6afeb7f9c72694f3cR2) [[4]](diffhunk://#diff-16d60416f4ad693a33283f5f425c4abf0e9cba6122fcf99bb7d725d33ab34815R6) [[5]](diffhunk://#diff-63fdbf1e782124a8f1b877953698b7f20b17138049f0870ce039fd34ba62aaa8R5-R6)

These changes enable per-texture control over filtering and mipmapping, improving rendering flexibility and quality.