### PR TITLE
added uv subregions implementation, push constants and shader changes

### DIFF
--- a/assets/shaders/Builtin.ObjectShader.vert.glsl
+++ b/assets/shaders/Builtin.ObjectShader.vert.glsl
@@ -11,11 +11,13 @@ layout(set = 0, binding = 0) uniform globalUniformObject {
 
 layout(push_constant) uniform pushConstants {
   layout(row_major) mat4 model;
+  vec2 uvOffset;
+  vec2 uvScale;
 } uPushConstants;
 
 layout(location = 0) out vec2 vTexCoord;
 
 void main() {
   gl_Position = globalUbo.projection * globalUbo.view * uPushConstants.model * vec4(inPosition, 1.0);
-  vTexCoord = inTexCoord;
+  vTexCoord = uPushConstants.uvOffset + inTexCoord * uPushConstants.uvScale;
 }

--- a/engine/src/Math/Vector2D.hpp
+++ b/engine/src/Math/Vector2D.hpp
@@ -10,7 +10,7 @@ class Vec2D {
 public:
   inline constexpr Vec2D() : _x(0.0f), _y(0.0f) {}
   inline constexpr Vec2D(float32 x, float32 y) : _x(x), _y(y) {}
-  inline Vec2D(const Vec2D &other) noexcept : _x(other._x), _y(other._y) {}
+  inline Vec2D(const Vec2D &other) noexcept = default;
 
   // Static factories (do not depend on instance)
   FEINLINE constexpr Vec2D Zero() { return Vec2D(0.0f, 0.0f); }

--- a/engine/src/Math/Vector3D.hpp
+++ b/engine/src/Math/Vector3D.hpp
@@ -12,7 +12,7 @@ class Vec3D {
 public:
   inline constexpr Vec3D() : _x(0.0f), _y(0.0f), _z(0.0f) {}
   inline constexpr Vec3D(float32 x, float32 y, float32 z) : _x(x), _y(y), _z(z) {}
-  inline Vec3D(const Vec3D &other) noexcept : _x(other._x), _y(other._y), _z(other._z) {}
+  inline Vec3D(const Vec3D &other) noexcept = default;
 
   // Static factories (do not depend on instance)
   FEINLINE constexpr Vec3D Zero() { return Vec3D(0.0f, 0.0f, 0.0f); }

--- a/engine/src/Renderer/RendererFrontend.cc
+++ b/engine/src/Renderer/RendererFrontend.cc
@@ -108,7 +108,8 @@ FeExpect<bool, Error> FrontendRenderer::DrawFrame(RenderPacket *pRenderPacket) {
 
   for (uint32 i = 0; i < pRenderPacket->objects.Length(); i++) {
     const RenderObject &object = pRenderPacket->objects[i];
-    _rendererState.pActiveBackend->DrawGeometry(object.geometryId, object.model, object.pMaterial);
+    const PushConstantData data{object.model, object.uvOffset, object.uvScale};
+    _rendererState.pActiveBackend->DrawGeometry(object.geometryId, data, object.pMaterial);
   }
 
   auto endRes = EndFrame(pRenderPacket->deltaTime);

--- a/engine/src/Renderer/RendererInterface.hpp
+++ b/engine/src/Renderer/RendererInterface.hpp
@@ -45,7 +45,7 @@ public:
                                                uint32 indexCount,
                                                const uint32 *pIndices) = 0;
   virtual FeExpect<void, Error> DestroyGeometry(uint32 id) = 0;
-  virtual void DrawGeometry(uint32 id, math::Mat4D model, const resources::Material *pMaterial) = 0;
+  virtual void DrawGeometry(uint32 id, const PushConstantData &data, const resources::Material *pMaterial) = 0;
 
   virtual FeExpect<void, Error> CreateMaterial(resources::Material *pMaterial,
                                                const resources::Texture *pTexture) = 0;

--- a/engine/src/Renderer/RendererTypes.hpp
+++ b/engine/src/Renderer/RendererTypes.hpp
@@ -10,6 +10,8 @@ namespace flatearth::renderer {
 struct RenderObject {
   uint32 geometryId;
   math::Mat4D model;
+  math::Vec2D uvOffset;
+  math::Vec2D uvScale;
   resources::Material *pMaterial{nullptr};
 };
 
@@ -27,6 +29,12 @@ struct GlobalUniformObject {
   // These below are so that GlobalUniformObject always
   // has a size of 256 bytes
   math::Mat4D reservedSpace1, reservedSpace2;
+};
+
+struct PushConstantData {
+  math::Mat4D model;
+  math::Vec2D uvOffset;
+  math::Vec2D uvScale;
 };
 
 } // namespace flatearth::renderer

--- a/engine/src/Renderer/Vulkan/Shaders/ObjectShader.cc
+++ b/engine/src/Renderer/Vulkan/Shaders/ObjectShader.cc
@@ -51,6 +51,8 @@ MakeLayoutBinding(const Context &ctx, ObjectShader *pObjShader, DescriptorBindin
                                        nullptr,
                                        VK_SHADER_STAGE_FRAGMENT_BIT);
   }
+
+  return FeErr{Error("unknown descriptor binding", ErrorType::RendererVulkanError)};
 }
 
 FeExpect<void, Error>
@@ -72,6 +74,8 @@ MakeDescriptorPool(const Context &ctx, ObjectShader *pObjectShader, DescriptorBi
                                   VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
                                   VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT);
   }
+
+  return FeErr{Error("unknown descriptor binding", ErrorType::RendererVulkanError)};
 }
 
 VulkanShader::VulkanShader(memory::MemoryManager &memManager, BufferManager &bufferManager)
@@ -336,7 +340,9 @@ FeExpect<void, Error> VulkanShader::UpdateGlobalState(Context &ctx, ObjectShader
   return {};
 }
 
-void VulkanShader::UpdateObject(Context &ctx, ObjectShader &objShader, math::Mat4D model) {
+void VulkanShader::UpdateObject(Context &ctx,
+                                ObjectShader &objShader,
+                                const PushConstantData &data) {
   uint32 imageIndex = ctx.imageIndex;
   VkCommandBuffer cmdBuffer = ctx.graphicsCommandBuffer[imageIndex].handle;
 
@@ -344,8 +350,8 @@ void VulkanShader::UpdateObject(Context &ctx, ObjectShader &objShader, math::Mat
                      objShader.pipeline.layout,
                      VK_SHADER_STAGE_VERTEX_BIT,
                      0,
-                     sizeof(math::Mat4D),
-                     &model);
+                     sizeof(PushConstantData),
+                     &data);
 }
 
 FeExpect<void, Error> VulkanShader::AcquireTextureResources(Context &ctx,

--- a/engine/src/Renderer/Vulkan/Shaders/ObjectShader.hpp
+++ b/engine/src/Renderer/Vulkan/Shaders/ObjectShader.hpp
@@ -30,7 +30,7 @@ public:
   FeExpect<void, Error> UpdateGlobalState(Context &ctx, ObjectShader &objShader);
 
   // temp method
-  void UpdateObject(Context &ctx, ObjectShader &objShader, math::Mat4D model);
+  void UpdateObject(Context &ctx, ObjectShader &objShader, const PushConstantData &data);
 
   FeExpect<void, Error>
   AcquireTextureResources(Context &ctx, ObjectShader &objShader, TextureData *pTextureData);

--- a/engine/src/Renderer/Vulkan/VulkanBackend.cc
+++ b/engine/src/Renderer/Vulkan/VulkanBackend.cc
@@ -698,10 +698,12 @@ FeExpect<void, Error> VulkanBackend::DestroyGeometry(uint32 id) {
 }
 
 void VulkanBackend::DrawGeometry(uint32 id,
-                                 math::Mat4D model,
+                                 const PushConstantData &data,
                                  const resources::Material *pMaterial) {
   CommandBuffer &cmdBuffer = _ctx.graphicsCommandBuffer[_ctx.imageIndex];
-  _vulkanShader.UpdateObject(_ctx, _ctx.objectShader, model.ToGPUMatrix());
+  PushConstantData gpuData = data;
+  gpuData.model = data.model.ToGPUMatrix();
+  _vulkanShader.UpdateObject(_ctx, _ctx.objectShader, gpuData);
   _vulkanShader.UseShader(_ctx, _ctx.objectShader);
 
   {

--- a/engine/src/Renderer/Vulkan/VulkanBackend.hpp
+++ b/engine/src/Renderer/Vulkan/VulkanBackend.hpp
@@ -6,6 +6,7 @@
 #include "Core/FeMemory.hpp"
 #include "Platform/Filesystem.hpp"
 #include "Renderer/RendererInterface.hpp"
+#include "Renderer/RendererTypes.hpp"
 #include "Renderer/Vulkan/Shaders/ObjectShader.hpp"
 #include "Renderer/Vulkan/VulkanBuffer.hpp"
 #include "Renderer/Vulkan/VulkanCommandBufferManager.hpp"
@@ -48,7 +49,7 @@ public:
                                        uint32 indexCount,
                                        const uint32 *pIndices) override;
   FeExpect<void, Error> DestroyGeometry(uint32 id) override;
-  void DrawGeometry(uint32 id, math::Mat4D model, const resources::Material *pMaterial) override;
+  void DrawGeometry(uint32 id, const PushConstantData &data, const resources::Material *pMaterial) override;
 
   FeExpect<void, Error> CreateMaterial(resources::Material *pMaterial,
                                        const resources::Texture *pTexture) override;

--- a/engine/src/Renderer/Vulkan/VulkanPipeline.cc
+++ b/engine/src/Renderer/Vulkan/VulkanPipeline.cc
@@ -1,6 +1,7 @@
 #include "VulkanPipeline.hpp"
 
 #include "Math/MathTypes.hpp"
+#include "Renderer/RendererTypes.hpp"
 #include "Renderer/Vulkan/VulkanTypes.hpp"
 
 #include <vulkan/vulkan_core.h>
@@ -128,8 +129,8 @@ PipelineManager::CreateGraphicsPipeline(Context &ctx,
   // Push constants
   VkPushConstantRange pushConstant;
   pushConstant.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
-  pushConstant.offset = sizeof(math::Mat4D) * 0;
-  pushConstant.size = sizeof(math::Mat4D) * 2;
+  pushConstant.offset = sizeof(PushConstantData) * 0;
+  pushConstant.size = sizeof(PushConstantData) * 1;
 
   pipelineLayoutInfo.setLayoutCount = descriptorSetLayoutCount;
   pipelineLayoutInfo.pSetLayouts = pDescriptorLayouts;

--- a/testbed/src/Game.cc
+++ b/testbed/src/Game.cc
@@ -132,17 +132,17 @@ bool GameTest::GameRender(flatearth::Game *, renderer::RenderPacket &packet) {
 
   _state.angle += packet.deltaTime * 1.5f;
   math::Mat4D model = math::Mat4D::RotationZ(_state.angle);
-  packet.objects.Push({_state.quadMesh, model, _state.pMaterial});
+  packet.objects.Push({_state.quadMesh, model, {}, {1.0f, 1.0f}, _state.pMaterial});
 
   _state.angle2 -= packet.deltaTime * 2.0f;
   math::Mat4D model2 =
       math::Mat4D::Translation(0.0f, 1.2f, 0.0f) * math::Mat4D::RotationZ(_state.angle2);
-  packet.objects.Push({_state.circleMesh, model2, _state.pMaterial});
+  packet.objects.Push({_state.circleMesh, model2, {}, {1.0f, 1.0f}, _state.pMaterial});
 
   _state.angle3 += packet.deltaTime * 1.0f;
   math::Mat4D model3 =
       math::Mat4D::Translation(-1.2f, 0.0f, 0.0f) * math::Mat4D::RotationZ(_state.angle3);
-  packet.objects.Push({_state.capsuleMesh, model3, _state.pMaterial2});
+  packet.objects.Push({_state.capsuleMesh, model3, {}, {1.0f, 1.0f}, _state.pMaterial2});
 
   return FeTrue;
 }


### PR DESCRIPTION
This pull request introduces support for per-object UV offset and scale in the rendering pipeline, enabling more flexible texture mapping for objects. It does so by extending the push constants and related data structures, updating shader code, and propagating these changes through the renderer interface and Vulkan backend. Additionally, some minor code cleanups and error handling improvements are included.

**Rendering pipeline enhancements:**

* Added `uvOffset` and `uvScale` fields to the `RenderObject` struct and the new `PushConstantData` struct, allowing each object to specify its own UV transformation. (`engine/src/Renderer/RendererTypes.hpp` [[1]](diffhunk://#diff-a8f9c3a2cbd119f6906b34db8089d260f827b3cc1f173f6c5083b6e7d3714a88R13-R14) [[2]](diffhunk://#diff-a8f9c3a2cbd119f6906b34db8089d260f827b3cc1f173f6c5083b6e7d3714a88R34-R39)
* Updated the Vulkan backend and renderer interface to accept `PushConstantData` instead of just the model matrix, ensuring UV parameters are passed through all layers. (`engine/src/Renderer/RendererInterface.hpp` [[1]](diffhunk://#diff-cfe671ce89612bd20b400e9359720b4d24df386bf15924257688816880ca5c50L48-R48) `engine/src/Renderer/Vulkan/VulkanBackend.hpp` [[2]](diffhunk://#diff-f7fd3814618b64b7d6c8dd3a65684dfe47ee4f657df5189c32cf0f7967cd3e3cL51-R52) [[3]](diffhunk://#diff-f7fd3814618b64b7d6c8dd3a65684dfe47ee4f657df5189c32cf0f7967cd3e3cR9) `engine/src/Renderer/RendererFrontend.cc` [[4]](diffhunk://#diff-c1832aa357d5f8c0b157ad91003e441db43527affe3524cc35007d94af5e5694L111-R112) `engine/src/Renderer/Vulkan/VulkanBackend.cc` [[5]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138L701-R706)
* Modified the vertex shader (`Builtin.ObjectShader.vert.glsl`) to apply UV offset and scale to the output texture coordinates. (`assets/shaders/Builtin.ObjectShader.vert.glsl` [assets/shaders/Builtin.ObjectShader.vert.glslR14-R22](diffhunk://#diff-ff30a33406dcad0b7a2009a7143e3e6051e6698745d8f8f217242f2fcf240a09R14-R22))
* Updated the Vulkan shader push constant logic and pipeline layout to handle the new `PushConstantData` structure, and updated the method signatures accordingly. (`engine/src/Renderer/Vulkan/Shaders/ObjectShader.cc` [[1]](diffhunk://#diff-11721be231726cd975f4b53abb0559b00cb65f297592d619aa1f519b48284531L339-R354) [[2]](diffhunk://#diff-11721be231726cd975f4b53abb0559b00cb65f297592d619aa1f519b48284531R54-R55) [[3]](diffhunk://#diff-11721be231726cd975f4b53abb0559b00cb65f297592d619aa1f519b48284531R77-R78) `engine/src/Renderer/Vulkan/Shaders/ObjectShader.hpp` [[4]](diffhunk://#diff-cf439b906ded027f444f4ee5b7f7b19b2a3ccc5381d4c22b8db5dd0ee75c4340L33-R33) `engine/src/Renderer/Vulkan/VulkanPipeline.cc` [[5]](diffhunk://#diff-c32f99e4cd6bc77dd23baa63ed1d8263e57034bb35a80bf90360be15930d5574L131-R133) [[6]](diffhunk://#diff-c32f99e4cd6bc77dd23baa63ed1d8263e57034bb35a80bf90360be15930d5574R4)

**Testbed and minor improvements:**

* Updated testbed object creation to supply UV offset and scale. (`testbed/src/Game.cc` [testbed/src/Game.ccL135-R145](diffhunk://#diff-cd8c5e92797463a5b1f5fbace0e697f28a5619e7432bc63a2317d3b520676ad8L135-R145))
* Simplified copy constructors for `Vec2D` and `Vec3D` using `= default`. (`engine/src/Math/Vector2D.hpp` [[1]](diffhunk://#diff-531f735c24aa8ce005966c97e334e8d1b2d8f31ebbf6ca03ad84ac3df5682857L13-R13) `engine/src/Math/Vector3D.hpp` [[2]](diffhunk://#diff-7b1a21f21137da21293a3bee5ff7ff6c3fcaf57cd0c5cebec9f1e6bbbd619147L15-R15)
* Improved error handling for unknown descriptor bindings in Vulkan shader code. (`engine/src/Renderer/Vulkan/Shaders/ObjectShader.cc` [[1]](diffhunk://#diff-11721be231726cd975f4b53abb0559b00cb65f297592d619aa1f519b48284531R54-R55) [[2]](diffhunk://#diff-11721be231726cd975f4b53abb0559b00cb65f297592d619aa1f519b48284531R77-R78)