### PR TITLE
Adding rendering layer (z-layer)

### DIFF
--- a/engine/src/Algorithms/StableSort.hpp
+++ b/engine/src/Algorithms/StableSort.hpp
@@ -1,0 +1,67 @@
+#ifndef _FLATEARTH_ENGINE_ALGORITHMS_STABLE_SORT_HPP
+#define _FLATEARTH_ENGINE_ALGORITHMS_STABLE_SORT_HPP
+
+#include "Containers/DArray.hpp"
+
+namespace flatearth::algorithms {
+
+namespace detail {
+
+template <typename T, typename Comp>
+static void Merge(T *arr,
+                  T *scratch,
+                  uint64 left,
+                  uint64 mid,
+                  uint64 right,
+                  memory::MemoryManager &mem,
+                  Comp comp) {
+  mem.CopyMemory(scratch + left, arr + left, (right - left) * sizeof(T));
+
+  uint64 i = left, j = mid, k = left;
+  while (i < mid && j < right) {
+    if (!comp(scratch[j], scratch[i])) {
+      arr[k++] = scratch[i++];
+    } else {
+      arr[k++] = scratch[j++];
+    }
+  }
+
+  while (i < mid) {
+    arr[k++] = scratch[i++];
+  }
+
+  while (j < right) {
+    arr[k++] = scratch[j++];
+  }
+}
+
+template <typename T, typename Comp>
+static void MergeSortImpl(
+    T *arr, T *scratch, uint64 left, uint64 right, memory::MemoryManager &mem, Comp comp) {
+  if (right - left <= 1) {
+    return;
+  }
+
+  uint64 mid = left + (right - left) / 2;
+  MergeSortImpl(arr, scratch, left, mid, mem, comp);
+  MergeSortImpl(arr, scratch, mid, right, mem, comp);
+  Merge(arr, scratch, left, mid, right, mem, comp);
+}
+
+} // namespace detail
+
+template <typename T, typename Comp>
+inline void StableSort(memory::MemoryManager &mem, containers::DArray<T> &arr, Comp comp) {
+  uint64 n = arr.Length();
+  if (n <= 1) {
+    return;
+  }
+
+  T *scratch = FeCast<T>(mem.RawAlloc(n * sizeof(T), alignof(T), memory::Tag::DArray));
+  detail::MergeSortImpl(arr.Data(), scratch, 0, n, mem, comp);
+  mem.RawFree(reinterpret_cast<std::byte *>(scratch), n * sizeof(T), memory::Tag::DArray);
+}
+
+}; // namespace flatearth::algorithms
+
+#endif // _FLATEARTH_ENGINE_CORE_ALGORITHMS_HPP

--- a/engine/src/Renderer/RendererFrontend.cc
+++ b/engine/src/Renderer/RendererFrontend.cc
@@ -1,5 +1,6 @@
 #include "Renderer/RendererFrontend.hpp"
 
+#include "Algorithms/StableSort.hpp"
 #include "Core/ApplicationConfig.hpp"
 #include "Core/FeMemory.hpp"
 #include "Core/Logger.hpp"
@@ -105,6 +106,11 @@ FeExpect<bool, Error> FrontendRenderer::DrawFrame(RenderPacket *pRenderPacket) {
     FLOG_ERROR("failed to update global state on frontend renderer");
     return FeErr{updateRes.error()};
   }
+
+  algorithms::StableSort(
+      _memoryManager, pRenderPacket->objects, [](const RenderObject &a, const RenderObject &b) {
+        return a.layer < b.layer;
+      });
 
   for (uint32 i = 0; i < pRenderPacket->objects.Length(); i++) {
     const RenderObject &object = pRenderPacket->objects[i];

--- a/engine/src/Renderer/RendererTypes.hpp
+++ b/engine/src/Renderer/RendererTypes.hpp
@@ -7,11 +7,20 @@
 
 namespace flatearth::renderer {
 
+enum class RenderLayer : uint32 {
+  Background = 0,
+  Tiles = 1,
+  Entities = 2,
+  Effects = 3,
+  UI = 4,
+};
+
 struct RenderObject {
   uint32 geometryId;
   math::Mat4D model;
   math::Vec2D uvOffset;
   math::Vec2D uvScale;
+  RenderLayer layer{RenderLayer::Background};
   resources::Material *pMaterial{nullptr};
 };
 

--- a/testbed/src/Game.cc
+++ b/testbed/src/Game.cc
@@ -132,17 +132,17 @@ bool GameTest::GameRender(flatearth::Game *, renderer::RenderPacket &packet) {
 
   _state.angle += packet.deltaTime * 1.5f;
   math::Mat4D model = math::Mat4D::RotationZ(_state.angle);
-  packet.objects.Push({_state.quadMesh, model, {}, {1.0f, 1.0f}, _state.pMaterial});
+  packet.objects.Push({_state.quadMesh, model, {}, {1.0f, 1.0f}, renderer::RenderLayer::Entities, _state.pMaterial});
 
   _state.angle2 -= packet.deltaTime * 2.0f;
   math::Mat4D model2 =
       math::Mat4D::Translation(0.0f, 1.2f, 0.0f) * math::Mat4D::RotationZ(_state.angle2);
-  packet.objects.Push({_state.circleMesh, model2, {}, {1.0f, 1.0f}, _state.pMaterial});
+  packet.objects.Push({_state.circleMesh, model2, {}, {1.0f, 1.0f}, renderer::RenderLayer::Entities, _state.pMaterial});
 
   _state.angle3 += packet.deltaTime * 1.0f;
   math::Mat4D model3 =
       math::Mat4D::Translation(-1.2f, 0.0f, 0.0f) * math::Mat4D::RotationZ(_state.angle3);
-  packet.objects.Push({_state.capsuleMesh, model3, {}, {1.0f, 1.0f}, _state.pMaterial2});
+  packet.objects.Push({_state.capsuleMesh, model3, {}, {1.0f, 1.0f}, renderer::RenderLayer::Entities, _state.pMaterial2});
 
   return FeTrue;
 }


### PR DESCRIPTION
This pull request introduces a stable sorting algorithm for render objects and updates the rendering pipeline to support explicit render layering. The main goals are to ensure render objects are drawn in the correct order and to make layer management more robust and type-safe.

**Rendering improvements:**

* Added a new `StableSort` implementation in `Algorithms/StableSort.hpp` using a merge sort algorithm to guarantee stable ordering of render objects.
* Integrated `StableSort` into the rendering pipeline (`RendererFrontend.cc`) to sort `RenderObject` instances by their `layer` field before drawing. [[1]](diffhunk://#diff-c1832aa357d5f8c0b157ad91003e441db43527affe3524cc35007d94af5e5694R3) [[2]](diffhunk://#diff-c1832aa357d5f8c0b157ad91003e441db43527affe3524cc35007d94af5e5694R110-R114)

**Render object and layer management:**

* Introduced a strongly-typed `RenderLayer` enum in `RendererTypes.hpp` and added a `layer` field to `RenderObject`, defaulting to `Background`.
* Updated testbed usage to explicitly set the `layer` for all pushed render objects, ensuring they are assigned to the correct layer (`Entities`).