### PR TITLE
fixes to make it work on windows

### DIFF
--- a/engine/src/Algorithms/StableSort.hpp
+++ b/engine/src/Algorithms/StableSort.hpp
@@ -15,7 +15,7 @@ static void Merge(T *arr,
                   uint64 right,
                   memory::MemoryManager &mem,
                   Comp comp) {
-  mem.CopyMemory(scratch + left, arr + left, (right - left) * sizeof(T));
+  mem.FCopyMemory(scratch + left, arr + left, (right - left) * sizeof(T));
 
   uint64 i = left, j = mid, k = left;
   while (i < mid && j < right) {

--- a/engine/src/Core/FeMemory.cc
+++ b/engine/src/Core/FeMemory.cc
@@ -49,11 +49,11 @@ MemoryManager::~MemoryManager() {
 
 void *MemoryManager::RawAlloc(uint64 size, uint64 alignment, Tag tag) {
   void *block = nullptr;
+  alignment = NormalizeAlignment(alignment);
 
 #if defined(_MSC_VER)
   block = _aligned_malloc(size, alignment);
 #else
-  alignment = NormalizeAlignment(alignment);
   const int rc = posix_memalign(&block, static_cast<size_t>(alignment), static_cast<size_t>(size));
   if (rc != 0) {
     block = nullptr;
@@ -113,7 +113,7 @@ void MemoryManager::FZeroMemory(void *block, uint64 size) {
   std::memset(block, 0, size);
 }
 
-void MemoryManager::CopyMemory(void *dst, const void *src, uint64 size) {
+void MemoryManager::FCopyMemory(void *dst, const void *src, uint64 size) {
   if (src == nullptr || dst == nullptr || size == 0) {
     return;
   }

--- a/engine/src/Core/FeMemory.hpp
+++ b/engine/src/Core/FeMemory.hpp
@@ -52,7 +52,7 @@ public:
   FEAPI void *RawAlloc(uint64 size, uint64 alignment, Tag tag);
   FEAPI void RawFree(void *block, uint64 size, Tag tag);
   FEAPI void FZeroMemory(void *block, uint64 size);
-  FEAPI void CopyMemory(void *dst, const void *src, uint64 size);
+  FEAPI void FCopyMemory(void *dst, const void *src, uint64 size);
 
   template <typename T, typename... Args>
   inline FePtr<T> Allocate(Tag tag, Args &&...args) {

--- a/engine/src/Renderer/Vulkan/VulkanBuffer.cc
+++ b/engine/src/Renderer/Vulkan/VulkanBuffer.cc
@@ -196,7 +196,7 @@ FeExpect<void, Error> BufferManager::LoadData(Context &ctx,
     return FeErr{res.error()};
   }
 
-  ctx.memoryManager.CopyMemory(dataPtr, data, size);
+  ctx.memoryManager.FCopyMemory(dataPtr, data, size);
   vkUnmapMemory(ctx.device.logicalDevice, buffer.memory);
   return {};
 }

--- a/engine/src/Renderer/Vulkan/VulkanImager.cc
+++ b/engine/src/Renderer/Vulkan/VulkanImager.cc
@@ -132,7 +132,7 @@ FeExpect<void, Error> ImageManager::TransitionImageLayout(Context &ctx,
   barrier.image = image.handle;
   barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
   barrier.subresourceRange.baseMipLevel = 0;
-  barrier.subresourceRange.layerCount = 1;
+  barrier.subresourceRange.levelCount = 1;
   barrier.subresourceRange.baseArrayLayer = 0;
   barrier.subresourceRange.layerCount = 1;
 


### PR DESCRIPTION
This pull request primarily refactors the memory copying utility in the codebase, standardizing the function name for clarity and consistency so that windows does not confuse it with any internals. It also corrects a Vulkan image barrier field name. The most important changes are grouped below:

### Memory Management Refactoring

* Renamed the `CopyMemory` method in `MemoryManager` to `FCopyMemory` and updated all usages throughout the codebase for consistency. This affects `FeMemory.cc`, `FeMemory.hpp`, `StableSort.hpp`, and `VulkanBuffer.cc`. [[1]](diffhunk://#diff-ced72ce51ee549d563d4a2fe68695b900a0050445ce37915f6671d9b8d226bc3L116-R116) [[2]](diffhunk://#diff-c4087e0f53c26299e0a9e3adaae637e832baee147b651d5ed6e068de42b03607L55-R55) [[3]](diffhunk://#diff-96ea71939e1ff1811ba4942b443251040a61a7c57058788b9517c68ba5a2b3b8L18-R18) [[4]](diffhunk://#diff-20bc08433b1275e3d8168b049321c6b19b075fc60f603139ef539fceaaeec9b8L199-R199)
* Ensured alignment normalization is always performed before memory allocation in `RawAlloc` by moving the `NormalizeAlignment` call to the top of the function in `FeMemory.cc`.

### Vulkan Image Barrier Correction

* Fixed a typo in the Vulkan image barrier setup by changing `layerCount` to `levelCount` for `subresourceRange` in `VulkanImager.cc`, ensuring correct behavior when transitioning image layouts.