### PR TITLE
lazy view query

### DIFF
--- a/engine/src/ECS/ComponentPool.hpp
+++ b/engine/src/ECS/ComponentPool.hpp
@@ -1,0 +1,45 @@
+#ifndef _FLATEARTH_ENGINE_ECS_COMPONENT_POOL_HPP
+#define _FLATEARTH_ENGINE_ECS_COMPONENT_POOL_HPP
+
+#include "Containers/SparseSet.hpp"
+#include "Core/FeMemory.hpp"
+
+namespace flatearth::ecs {
+
+class ISparseSetBase {
+public:
+  virtual ~ISparseSetBase() = default;
+  virtual void Remove(uint32 entityIndex) = 0;
+  virtual uint32 *Entities() = 0;
+  virtual uint64 Length() const = 0;
+};
+
+template <typename T>
+class SparseSetHolder final : public ISparseSetBase {
+public:
+  explicit SparseSetHolder(memory::MemoryManager &memManager, uint32 maxEntities)
+      : sparseSet(memManager, maxEntities) {}
+
+  void Remove(uint32 entityIndex) override { sparseSet.Remove(entityIndex); }
+  uint32 *Entities() override { return sparseSet.Entities(); }
+  uint64 Length() const override { return sparseSet.Length(); }
+
+public:
+  containers::SparseSet<T> sparseSet;
+};
+
+struct ComponentTypeIdCounter {
+  inline static uint32 sCounter{0};
+};
+
+template <typename T>
+struct ComponentTypeId {
+  static uint32 Value() {
+    static uint32 id = ComponentTypeIdCounter::sCounter++;
+    return id;
+  }
+};
+
+} // namespace flatearth::ecs
+
+#endif // _FLATEARTH_ENGINE_ECS_COMPONENT_POOL_HPP

--- a/engine/src/ECS/Registry.hpp
+++ b/engine/src/ECS/Registry.hpp
@@ -2,41 +2,12 @@
 #define _FLATEARTH_ENGINE_ECS_REGISTRY_HPP
 
 #include "Containers/HashMap.hpp"
-#include "Containers/SparseSet.hpp"
 #include "Core/FeMemory.hpp"
+#include "ECS/ComponentPool.hpp"
 #include "ECS/EntityManager.hpp"
+#include "ECS/View.hpp"
 
 namespace flatearth::ecs {
-
-class ISparseSetBase {
-public:
-  virtual ~ISparseSetBase() = default;
-  virtual void Remove(uint32 entityIndex) = 0;
-};
-
-template <typename T>
-class SparseSetHolder final : public ISparseSetBase {
-public:
-  explicit SparseSetHolder(memory::MemoryManager &memManager, uint32 maxEntities)
-      : sparseSet(memManager, maxEntities) {}
-
-  void Remove(uint32 entityIndex) override { sparseSet.Remove(entityIndex); };
-
-public:
-  containers::SparseSet<T> sparseSet;
-};
-
-struct ComponentTypeIdCounter {
-  inline static uint32 sCounter{0};
-};
-
-template <typename T>
-struct ComponentTypeId {
-  static uint32 Value() {
-    static uint32 id = ComponentTypeIdCounter::sCounter++;
-    return id;
-  }
-};
 
 class Registry {
 public:
@@ -93,6 +64,11 @@ public:
     const FePtr<ISparseSetBase> *ppBase = _poolsMap.Retrieve(typeId);
     if (ppBase == nullptr) return false;
     return static_cast<const SparseSetHolder<T> *>(ppBase->get())->sparseSet.Has(id);
+  }
+
+  template <typename ...Ts>
+  View<Ts...> ViewOf() {
+    return View<Ts...>(GetPool<Ts>()...);
   }
 
 private:

--- a/engine/src/ECS/View.hpp
+++ b/engine/src/ECS/View.hpp
@@ -1,0 +1,84 @@
+#ifndef _FLATEARTH_ENGINE_ECS_VIEW_HPP
+#define _FLATEARTH_ENGINE_ECS_VIEW_HPP
+
+#include "Containers/SparseSet.hpp"
+#include "ECS/ComponentPool.hpp"
+#include "ECS/ECSTypes.hpp"
+
+#include <limits>
+#include <tuple>
+
+namespace flatearth::ecs {
+
+template <typename... Ts>
+class View {
+public:
+  explicit View(containers::SparseSet<Ts> *...sets)
+      : _sets(sets...) {
+    _pDriver = FindSmallest();
+  }
+
+  struct Iterator {
+    View  &_view;
+    uint32 _index;
+
+    bool operator!=(const Iterator &other) const { return _index != other._index; }
+
+    Iterator &operator++() {
+      ++_index;
+      Advance();
+      return *this;
+    }
+
+    std::tuple<EntityId, Ts &...> operator*() {
+      EntityId id = _view._pDriver->Entities()[_index];
+      return {id, _view.Get<Ts>(id)...};
+    }
+
+  private:
+    void Advance() {
+      while (_index < _view._pDriver->Length() &&
+             !_view.HasAll(_view._pDriver->Entities()[_index]))
+        ++_index;
+    }
+  };
+
+  Iterator begin() {
+    Iterator it{*this, 0};
+    it.Advance();
+    return it;
+  }
+
+  Iterator end() { return {*this, static_cast<uint32>(_pDriver->Length())}; }
+
+  bool Empty() const { return _pDriver == nullptr || _pDriver->Length() == 0; }
+
+private:
+  std::tuple<containers::SparseSet<Ts> *...> _sets;
+  ISparseSetBase *_pDriver{nullptr};
+
+  template <typename T>
+  containers::SparseSet<T> *GetSet() {
+    return std::get<containers::SparseSet<T> *>(_sets);
+  }
+
+  template <typename T>
+  T &Get(EntityId id) { return GetSet<T>()->Get(id); }
+
+  bool HasAll(EntityId id) {
+    return (... && std::get<containers::SparseSet<Ts> *>(_sets)->Has(id));
+  }
+
+  ISparseSetBase *FindSmallest() {
+    ISparseSetBase *pSmallest = nullptr;
+    uint64 minLen = std::numeric_limits<uint64>::max();
+    std::apply([&](auto *...sets) {
+      ((sets->Length() < minLen ? (minLen = sets->Length(), pSmallest = sets) : nullptr), ...);
+    }, _sets);
+    return pSmallest;
+  }
+};
+
+} // namespace flatearth::ecs
+
+#endif // _FLATEARTH_ENGINE_ECS_VIEW_HPP

--- a/engine/src/GameTypes.hpp
+++ b/engine/src/GameTypes.hpp
@@ -7,11 +7,12 @@
 
 #include <functional>
 
+// TODO: remove this once EngineContext exists
 namespace flatearth::resources {
 class TextureSystem;
 class MaterialSystem;
 class MeshSystem;
-}
+} // namespace flatearth::resources
 
 namespace flatearth::renderer {
 class FrontendRenderer;
@@ -33,18 +34,21 @@ public:
   std::function<bool(struct Game *gameInstance, uint32 width, uint32 height)> OnResize;
 
   Game()
-      : Initialize(nullptr), Load(nullptr), Unload(nullptr), Update(nullptr), Render(nullptr), OnResize(nullptr),
-        gameName(cGameName), windowStartWidth(scDefaultStartWidth),
+      : Initialize(nullptr), Load(nullptr), Unload(nullptr), Update(nullptr), Render(nullptr),
+        OnResize(nullptr), gameName(cGameName), windowStartWidth(scDefaultStartWidth),
         windowStartHeight(scDefaultStartHeight) {}
 
   Game(const string &name)
-      : Initialize(nullptr), Load(nullptr), Unload(nullptr), Update(nullptr), Render(nullptr), OnResize(nullptr),
-        gameName(name), windowStartWidth(scDefaultStartWidth),
+      : Initialize(nullptr), Load(nullptr), Unload(nullptr), Update(nullptr), Render(nullptr),
+        OnResize(nullptr), gameName(name), windowStartWidth(scDefaultStartWidth),
         windowStartHeight(scDefaultStartHeight) {}
 
 public:
   string gameName;
   int32 windowStartPosX, windowStartPosY, windowStartWidth, windowStartHeight;
+
+  // TODO: these are only here so that we can get it up and running. REMOVE
+  // LATER
   input::InputManager *pInputManager{nullptr};
   resources::TextureSystem *pTextureSystem{nullptr};
   resources::MaterialSystem *pMaterialSystem{nullptr};


### PR DESCRIPTION
This pull request introduces a new ECS (Entity Component System) view mechanism and refactors component pool and type ID management to improve modularity and code reuse. The main changes involve extracting common ECS component pool logic into a new header, implementing a generic `View` class for iterating over entities with specific components, and cleaning up the `Registry` implementation.

**ECS Infrastructure Improvements:**

* Extracted `ISparseSetBase`, `SparseSetHolder`, and component type ID logic from `Registry.hpp` into a new file `ComponentPool.hpp` for better separation of concerns and code reuse. [[1]](diffhunk://#diff-7b9d9d2dc23e02bc9686d8f4b6031afea0a68e281bf438fcd4dc47015c2c8240R1-R45) [[2]](diffhunk://#diff-49765cacfc9e6f2811dc3f46aa94ab35c8b2b8a9eff25c2e86e1e91bfbca8fddL5-L40)
* Implemented a new generic `View` class in `View.hpp`, allowing efficient iteration over entities matching a set of components. The view automatically selects the smallest component set as the driver for iteration.
* Added a `ViewOf<Ts...>()` method to `Registry`, enabling users to easily create views for specific component combinations.

**Code Cleanup and Minor Changes:**

* Updated `GameTypes.hpp` to clarify namespace usage and added TODO comments for future refactoring. Also, adjusted member initialization in the `Game` struct for clarity. [[1]](diffhunk://#diff-8d7039d912d0ae2089cb95e7bacb535d24b4d3630b56eb04cb54feb96420e476R10-R15) [[2]](diffhunk://#diff-8d7039d912d0ae2089cb95e7bacb535d24b4d3630b56eb04cb54feb96420e476L36-R51)