### PR TITLE
authority for future networking integration

### DIFF
--- a/engine/src/ECS/Reflect/Authority.hpp
+++ b/engine/src/ECS/Reflect/Authority.hpp
@@ -1,0 +1,42 @@
+#ifndef _FLATEARTH_ENGINE_ECS_REFLECT_AUTHORITY_HPP
+#define _FLATEARTH_ENGINE_ECS_REFLECT_AUTHORITY_HPP
+
+#include "Defines.hpp"
+
+namespace flatearth::ecs::reflect {
+
+// Ownership model for networked components.
+//
+// Local  — never replicated; exists only on the machine that owns it.
+// Server — server is authoritative; clients receive updates, never write.
+// Client — owning client is authoritative; server relays, others receive.
+// Shared — any peer may write; last-write-wins (use sparingly).
+//
+// Conflict resolution (Phase 8): Server > Client > Shared > Local.
+// Rollback interaction: only Server and Client components are included in
+// ECS snapshots used by the rollback system; Local components are skipped.
+enum class Authority : uint8 {
+  Local = 0,
+  Server = 1,
+  Client = 2,
+  Shared = 3,
+};
+
+constexpr const char *AuthorityName(Authority a) {
+  switch (a) {
+    case Authority::Local:
+      return "Local";
+    case Authority::Client:
+      return "Client";
+    case Authority::Server:
+      return "Server";
+    case Authority::Shared:
+      return "Shared";
+  }
+
+  return "Unknown";
+}
+
+} // namespace flatearth::ecs::reflect
+
+#endif // _FLATEARTH_ENGINE_ECS_REFLECT_AUTHORITY_HPP

--- a/engine/src/ECS/Reflect/FieldType.hpp
+++ b/engine/src/ECS/Reflect/FieldType.hpp
@@ -6,6 +6,7 @@
 namespace flatearth::ecs::reflect {
 
 enum class FieldType : uint8 {
+  Null,
   Bool,
   Int8,
   Int16,

--- a/engine/src/ECS/Reflect/Reflect.hpp
+++ b/engine/src/ECS/Reflect/Reflect.hpp
@@ -1,6 +1,7 @@
 #ifndef _FLATEARTH_ENGINE_ECS_REFLECT_REFLECT_HPP
 #define _FLATEARTH_ENGINE_ECS_REFLECT_REFLECT_HPP
 
+#include "Authority.hpp"
 #include "TypeRegistry.hpp"
 
 // ── public API ───────────────────────────────────────────────────────────────
@@ -11,28 +12,39 @@
 //       FIELD(y,        FieldType::Float32)
 //       FIELD(rotation, FieldType::Float32)
 //   END_REFLECT
+//
+//   REFLECT_COMPONENT(NetPos, Authority::Server)
+//       FIELD(x, FieldType::Float32)
+//   END_REFLECT
 
 #define _FE_CONCAT2(a, b) a##b
 #define _FE_CONCAT(a, b)  _FE_CONCAT2(a, b)
 #define _FE_UNIQUE(base)  _FE_CONCAT(base, __COUNTER__)
 
-#define REFLECT_COMPONENT(Type)                       \
-  namespace {                                         \
-  struct _Reflector_##Type {                          \
-    _Reflector_##Type() {                             \
-      using T = Type;                                 \
-      ::flatearth::ecs::reflect::TypeDescriptor desc; \
-      desc.name = #Type;                              \
+#define _REFLECT_COMPONENT_IMPL(Type, Auth)                   \
+  namespace {                                                  \
+  struct _Reflector_##Type {                                   \
+    _Reflector_##Type() {                                      \
+      using T = Type;                                          \
+      ::flatearth::ecs::reflect::TypeDescriptor desc;          \
+      desc.name      = #Type;                                  \
+      desc.authority = (Auth);                                 \
       desc.fields = {
+
+#define _FE_REFLECT_GET3(_1, _2, NAME, ...) NAME
+#define _REFLECT_COMPONENT_2(Type, Auth) _REFLECT_COMPONENT_IMPL(Type, Auth)
+#define _REFLECT_COMPONENT_1(Type)       _REFLECT_COMPONENT_IMPL(Type, ::flatearth::ecs::reflect::Authority::Local)
+
+#define REFLECT_COMPONENT(...) \
+  _FE_REFLECT_GET3(__VA_ARGS__, _REFLECT_COMPONENT_2, _REFLECT_COMPONENT_1)(__VA_ARGS__)
 
 #define FIELD(name, ftype) {#name, static_cast<uint32>(offsetof(T, name)), ftype},
 
 #define END_REFLECT                                                        \
-  }                                                                        \
-  ;                                                                        \
-  ::flatearth::ecs::reflect::TypeRegistry::Register<T>(std::move(desc));  \
-  }                                                                        \
-  } _FE_UNIQUE(_reflector_instance_);                                       \
+      };                                                                   \
+      ::flatearth::ecs::reflect::TypeRegistry::Register<T>(std::move(desc)); \
+    }                                                                      \
+  } _FE_UNIQUE(_reflector_instance_);                                      \
   }
 
 #endif

--- a/engine/src/ECS/Reflect/TypeDescriptor.hpp
+++ b/engine/src/ECS/Reflect/TypeDescriptor.hpp
@@ -2,21 +2,23 @@
 #define _FLATEARTH_ENGINE_ECS_REFLECT_TYPE_DESCRIPTOR_HPP
 
 #include "FieldType.hpp"
+#include "Authority.hpp"
 
 #include <vector>
 
 namespace flatearth::ecs::reflect {
 
 struct FieldDescriptor {
-  stringv name;
-  uint32 offset;
-  FieldType type;
+  stringv name{""};
+  uint32 offset{0};
+  FieldType type{FieldType::Null};
 };
 
 struct TypeDescriptor {
-  stringv name;
-  uint32 typeId;
-  std::vector<FieldDescriptor> fields;
+  stringv name{""};
+  uint32 typeId{0};
+  Authority authority{Authority::Local};
+  std::vector<FieldDescriptor> fields{};
 };
 
 } // namespace flatearth::ecs::reflect

--- a/tests/src/ECS/Test_Authority.cc
+++ b/tests/src/ECS/Test_Authority.cc
@@ -1,0 +1,99 @@
+#include "ECS/Reflect/Authority.hpp"
+#include "ECS/Reflect/Reflect.hpp"
+
+#include <string_view>
+#include <functional>
+
+void RegisterTest(std::string_view name, std::function<bool()> fn);
+
+using namespace flatearth;
+using namespace flatearth::ecs::reflect;
+
+#define ASSERT(expr) do { if (!(expr)) return false; } while(0)
+#define PASS return true
+
+// ── test components ──────────────────────────────────────────────────────────
+
+struct AuthLocalComp  { float x; };
+struct AuthServerComp { float x; float y; };
+struct AuthClientComp { int32_t score; };
+struct AuthSharedComp { bool flag; };
+
+REFLECT_COMPONENT(AuthLocalComp)
+    FIELD(x, FieldType::Float32)
+END_REFLECT
+
+REFLECT_COMPONENT(AuthServerComp, Authority::Server)
+    FIELD(x, FieldType::Float32)
+    FIELD(y, FieldType::Float32)
+END_REFLECT
+
+REFLECT_COMPONENT(AuthClientComp, Authority::Client)
+    FIELD(score, FieldType::Int32)
+END_REFLECT
+
+REFLECT_COMPONENT(AuthSharedComp, Authority::Shared)
+    FIELD(flag, FieldType::Bool)
+END_REFLECT
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+static bool test_default_authority_is_local() {
+    const TypeDescriptor *desc = TypeRegistry::Get<AuthLocalComp>();
+    ASSERT(desc != nullptr);
+    ASSERT(desc->authority == Authority::Local);
+    PASS;
+}
+
+static bool test_server_authority_stored() {
+    const TypeDescriptor *desc = TypeRegistry::Get<AuthServerComp>();
+    ASSERT(desc != nullptr);
+    ASSERT(desc->authority == Authority::Server);
+    PASS;
+}
+
+static bool test_client_authority_stored() {
+    const TypeDescriptor *desc = TypeRegistry::Get<AuthClientComp>();
+    ASSERT(desc != nullptr);
+    ASSERT(desc->authority == Authority::Client);
+    PASS;
+}
+
+static bool test_shared_authority_stored() {
+    const TypeDescriptor *desc = TypeRegistry::Get<AuthSharedComp>();
+    ASSERT(desc != nullptr);
+    ASSERT(desc->authority == Authority::Shared);
+    PASS;
+}
+
+static bool test_authority_name_strings() {
+    ASSERT(std::string_view(AuthorityName(Authority::Local))  == "Local");
+    ASSERT(std::string_view(AuthorityName(Authority::Server)) == "Server");
+    ASSERT(std::string_view(AuthorityName(Authority::Client)) == "Client");
+    ASSERT(std::string_view(AuthorityName(Authority::Shared)) == "Shared");
+    PASS;
+}
+
+static bool test_authority_does_not_affect_fields() {
+    const TypeDescriptor *desc = TypeRegistry::Get<AuthServerComp>();
+    ASSERT(desc != nullptr);
+    ASSERT(desc->fields.size() == 2);
+    ASSERT(desc->fields[0].name == "x");
+    ASSERT(desc->fields[1].name == "y");
+    PASS;
+}
+
+// ── registration ─────────────────────────────────────────────────────────────
+
+namespace {
+struct Reg {
+    Reg() {
+        RegisterTest("authority: default is Local",          test_default_authority_is_local);
+        RegisterTest("authority: Server stored correctly",   test_server_authority_stored);
+        RegisterTest("authority: Client stored correctly",   test_client_authority_stored);
+        RegisterTest("authority: Shared stored correctly",   test_shared_authority_stored);
+        RegisterTest("authority: AuthorityName strings",     test_authority_name_strings);
+        RegisterTest("authority: fields unaffected by auth", test_authority_does_not_affect_fields);
+    }
+} gReg;
+}


### PR DESCRIPTION
This pull request introduces an ownership model for networked ECS components by adding an `Authority` enum, updating the reflection system to support per-component authority, and providing comprehensive tests. The main changes are the addition of the authority concept, updates to the reflection macros and descriptors, and new tests to validate the implementation.

**Authority Model Integration:**
- Added `Authority` enum and helper function `AuthorityName()` to represent and stringify component ownership models (`Local`, `Server`, `Client`, `Shared`).
- Updated `TypeDescriptor` to include an `authority` field with a default of `Authority::Local`.
- Modified reflection macros to allow specifying authority per component (e.g., `REFLECT_COMPONENT(Type, Authority::Server)`), defaulting to `Local` when not specified.

**Reflection System Enhancements:**
- Updated `FieldType` to include a `Null` type and provided default values for `FieldDescriptor` fields. [[1]](diffhunk://#diff-7116d2c7e5f77541872558f1560e28d408054f123a5ea64d9ee3d08643bdf4b9R9) [[2]](diffhunk://#diff-d868684d14b4447a402ddeda6faae42acf76f961454ae45ca6f7465fd0f88fd5R5-R21)
- Ensured all relevant headers include the new `Authority.hpp` where needed. [[1]](diffhunk://#diff-c5cb53c6e9a40b317d3fa0e8c294e7e8fb2e0bebed9c04b43cea86d79ae650f0R4) [[2]](diffhunk://#diff-d868684d14b4447a402ddeda6faae42acf76f961454ae45ca6f7465fd0f88fd5R5-R21)

**Testing:**
- Added a new test file `Test_Authority.cc` that verifies correct authority assignment, stringification, and that authority does not affect field registration.

These changes collectively provide a flexible and explicit way to specify and query component authority in the ECS reflection system.