### PR TITLE
Asset Manager | Refactor | Sprites

### DIFF
--- a/engine/src/Assets/AssetManager.cc
+++ b/engine/src/Assets/AssetManager.cc
@@ -1,0 +1,86 @@
+#include "AssetManager.hpp"
+
+#include "Core/FeMemory.hpp"
+#include "Platform/Filesystem.hpp"
+#include "Renderer/RendererFrontend.hpp"
+#include "Resources/ResourceTypes.hpp"
+#include "Scene/Components/Sprite.hpp"
+
+namespace flatearth::assets {
+
+AssetManager::AssetManager(memory::MemoryManager &memManager,
+                           platform::FileSystem &fs)
+    : _textureCache(memManager, fs), _memoryManager(memManager),
+      _fs(fs) {
+}
+
+void AssetManager::Initialize(renderer::FrontendRenderer *pRenderer) {
+  if (pRenderer == nullptr) {
+    return;
+  }
+
+  _textureCache.Initialize(pRenderer);
+  _pRenderer = pRenderer;
+}
+
+FeExpect<resources::TextureHandle, Error>
+AssetManager::LoadTexture(stringv path, resources::TextureFilter filter) {
+  return _textureCache.AcquireTexture(string(path), filter);
+}
+
+void AssetManager::ReleaseTexture(resources::TextureHandle handle) {
+  _textureCache.Release(handle);
+}
+
+resources::Texture *AssetManager::GetTexture(resources::TextureHandle handle) {
+  return _textureCache.Get(handle);
+}
+
+FeExpect<scene::Sprite, Error> AssetManager::LoadSprite(stringv path,
+                                                        resources::MeshShape shape,
+                                                        resources::TextureFilter filter) {
+  auto loadRes = LoadTexture(path, filter);
+  if (!loadRes.has_value()) {
+    return FeErr{loadRes.error()};
+  }
+
+  resources::TextureHandle handle = loadRes.value();
+  scene::Sprite sprite{};
+  sprite.texHandle = handle;
+
+  resources::Texture *pTexture = GetTexture(handle);
+  if (pTexture == nullptr) {
+    return FeErr{Error("cannot create sprite with nullptr texture", ErrorType::NullptrException)};
+  }
+
+  auto acMatRes = _pRenderer->AcquireMaterial(string(path), pTexture);
+  if (!acMatRes.has_value()) {
+    return FeErr{acMatRes.error()};
+  }
+  sprite.matHandle = acMatRes.value();
+
+  auto acMeshRes = _pRenderer->AcquireMesh(shape);
+  if (!acMeshRes.has_value()) {
+    return FeErr{acMeshRes.error()};
+  }
+  sprite.meshHandle = acMeshRes.value();
+
+  return std::move(sprite);
+}
+
+void AssetManager::ReleaseSprite(scene::Sprite &sprite) {
+  _pRenderer->ReleaseMaterial(sprite.matHandle);
+  _pRenderer->ReleaseMesh(sprite.meshHandle);
+  ReleaseTexture(sprite.texHandle);
+  sprite = scene::Sprite{};
+}
+
+void AssetManager::Shutdown() {
+  _textureCache.Shutdown();
+}
+
+bool AssetManager::Initialized() const {
+  return _pRenderer != nullptr;
+}
+
+} // namespace flatearth::assets

--- a/engine/src/Assets/AssetManager.hpp
+++ b/engine/src/Assets/AssetManager.hpp
@@ -1,0 +1,46 @@
+#ifndef _FLATEARTH_ENGINE_ASSETS_ASSET_MANAGER_HPP
+#define _FLATEARTH_ENGINE_ASSETS_ASSET_MANAGER_HPP
+
+#include "Core/FeMemory.hpp"
+#include "Platform/Filesystem.hpp"
+#include "Renderer/RendererFrontend.hpp"
+#include "Resources/ResourceTypes.hpp"
+#include "Resources/TextureCache.hpp"
+
+#include <Scene/Components/Sprite.hpp>
+
+namespace flatearth::assets {
+
+class AssetManager {
+public:
+  explicit AssetManager(memory::MemoryManager &memManager,
+                        platform::FileSystem &fs);
+
+  void Initialize(renderer::FrontendRenderer *pRenderer);
+
+  FEAPI FeExpect<resources::TextureHandle, Error>
+  LoadTexture(stringv path, resources::TextureFilter filter = resources::TextureFilter::Nearest);
+  FEAPI void ReleaseTexture(resources::TextureHandle handle);
+  FEAPI resources::Texture *GetTexture(resources::TextureHandle handle);
+
+  FEAPI FeExpect<scene::Sprite, Error>
+  LoadSprite(stringv path,
+             resources::MeshShape shape,
+             resources::TextureFilter filter = resources::TextureFilter::Nearest);
+
+  FEAPI void ReleaseSprite(scene::Sprite &sprite);
+
+  FEAPI void Shutdown();
+
+  FEAPI bool Initialized() const;
+
+private:
+  resources::TextureCache _textureCache;
+  memory::MemoryManager &_memoryManager;
+  platform::FileSystem &_fs;
+  renderer::FrontendRenderer *_pRenderer;
+};
+
+} // namespace flatearth::assets
+
+#endif // _FLATEARTH_ENGINE_ASSETS_ASSET_MANAGER_HPP

--- a/engine/src/Core/Application.cc
+++ b/engine/src/Core/Application.cc
@@ -8,26 +8,27 @@
 #include "Core/Logger.hpp"
 #include "Defines.hpp"
 #include "Error.hpp"
+#include "Scene/Systems/SpriteSystem.hpp"
+#include "Scene/Systems/TransformSystem.hpp"
 
 namespace flatearth {
 
 Engine::Engine(Game *pGame)
     : _appState(pGame), _eventManager(_memoryManager), _inputManager(_eventManager),
-      _frontendRenderer(&_appState, _memoryManager, _filesystem), _filesystem(_memoryManager),
-      _textureCache(_memoryManager, _frontendRenderer, _filesystem),
-      _materialCache(_memoryManager, _frontendRenderer, _textureCache),
-      _meshCache(_memoryManager, _frontendRenderer) {
+      _renderer(&_appState, _memoryManager, _registry, _filesystem), _filesystem(_memoryManager),
+      _assetManager(_memoryManager, _filesystem), _scheduler(_memoryManager),
+      _registry(_memoryManager),
+      _ctx(_memoryManager, _assetManager, _inputManager, _registry) {
   _engineListener = _memoryManager.Allocate<event::IEventListener, EngineListener>(
-      memory::Tag::Application, _eventManager, _appState, _frontendRenderer);
+      memory::Tag::Application, _eventManager, _renderer, _appState);
 }
 
 Engine::~Engine() {
   if (_appState.pGameInstance->Unload) {
     _appState.pGameInstance->Unload(_appState.pGameInstance);
   }
-  _meshCache.Shutdown();
-  _materialCache.Shutdown();
-  _textureCache.Shutdown();
+  _renderer.Shutdown();
+  _assetManager.Shutdown();
   FLOG_INFO("engine shutdown gracefully");
 }
 
@@ -37,6 +38,8 @@ FeExpect<void, Error> Engine::Initialize() {
     FLOG_ERROR("game has undefined callbacks: {}", checkRes.error().message);
     return FeErr{checkRes.error()};
   }
+
+  _appState.pGameInstance->pCtx = &_ctx;
 
   // initialize game
   if (!_appState.pGameInstance->Initialize(_appState.pGameInstance)) {
@@ -73,26 +76,41 @@ FeExpect<void, Error> Engine::Initialize() {
     return FeErr{listenerInitRes.error()};
   }
 
-  FeExpect<bool, Error> frontendInitRes = _frontendRenderer.Initialize();
-  if (!frontendInitRes.has_value()) {
-    FLOG_ERROR("frontend renderer failed to initialize: {}", frontendInitRes.error().message);
-    return FeErr{frontendInitRes.error()};
+  FeExpect<bool, Error> renderInitRes = _renderer.Initialize();
+  if (!renderInitRes.has_value()) {
+    FLOG_ERROR("game renderer failed to initialize: {}", renderInitRes.error().message);
+    return FeErr{renderInitRes.error()};
   }
+
+  _assetManager.Initialize(&_renderer.FrontendReference());
 
   _appState.isRunning = FeTrue;
   _appState.isSuspended = FeFalse;
   _appState.platformState = _pPlatform->State();
-  _appState.pGameInstance->pInputManager = &_inputManager;
-  _appState.pGameInstance->pTextureCache = &_textureCache;
-  _appState.pGameInstance->pMaterialCache = &_materialCache;
-  _appState.pGameInstance->pMeshCache = &_meshCache;
-  _appState.pGameInstance->pRenderer = &_frontendRenderer;
 
   if (_appState.pGameInstance->Load) {
     if (!_appState.pGameInstance->Load(_appState.pGameInstance)) {
       FLOG_FATAL("game failed to load resources");
       return FeErr{Error("game Load() failed", ErrorType::GameInitializeError)};
     }
+  }
+
+  auto registerRes = _scheduler.Register<systems::TransformSystem>(_memoryManager);
+  if (!registerRes.has_value()) {
+    FLOG_ERROR("could not register TransformSystem into scheduler");
+    return FeErr{registerRes.error()};
+  }
+
+  auto spriteRes = _scheduler.Register<systems::SpriteSystem>();
+  if (!spriteRes.has_value()) {
+    FLOG_ERROR("could not register SpriteSystem into scheduler");
+    return FeErr{spriteRes.error()};
+  }
+
+  auto buildRes = _scheduler.Build();
+  if (!buildRes.has_value()) {
+    FLOG_ERROR("failed to build scheduler");
+    return FeErr{buildRes.error()};
   }
 
   FLOG_INFO("engine successfully initialized");
@@ -134,18 +152,11 @@ FeExpect<void, Error> Engine::Start() {
       break;
     }
 
-    // Hardcoded just to make it up and running
-    // TODO: remove
-    renderer::RenderPacket packet(_memoryManager);
-    packet.deltaTime = deltaTime;
-    if (!_appState.pGameInstance->Render(_appState.pGameInstance, packet)) {
-      FLOG_FATAL("could not populate render packet inside game instance");
-      break;
-    }
+    _scheduler.Update(_registry, deltaTime);
 
-    auto drawRes = _frontendRenderer.DrawFrame(&packet);
+    auto drawRes = _renderer.Draw(deltaTime);
     if (!drawRes.has_value()) {
-      FLOG_ERROR("frontend renderer failed to draw frame: {}", drawRes.error().message);
+      FLOG_ERROR("game renderer failed to draw frame: {}", drawRes.error().message);
       return FeErr{drawRes.error()};
     }
 
@@ -182,11 +193,6 @@ FeExpect<void, Error> Engine::CheckGamePrerequisites() {
   if (_appState.pGameInstance->Update == nullptr) {
     return FeErr{
         Error("game instance Update() function is not defined", ErrorType::GameUpdateUndefined)};
-  }
-
-  if (_appState.pGameInstance->Render == nullptr) {
-    return FeErr{
-        Error("game instance Render() function is not defined", ErrorType::GameUpdateUndefined)};
   }
 
   if (_appState.pGameInstance->OnResize == nullptr) {

--- a/engine/src/Core/Application.hpp
+++ b/engine/src/Core/Application.hpp
@@ -1,16 +1,17 @@
 #ifndef _FLATEARTH_ENGINE_CORE_APPLICATION_HPP
 #define _FLATEARTH_ENGINE_CORE_APPLICATION_HPP
 
+#include "Assets/AssetManager.hpp"
 #include "Core/ApplicationConfig.hpp"
 #include "Core/Event.hpp"
 #include "Core/Input.hpp"
+#include "ECS/Registry.hpp"
+#include "ECS/Scheduler/SystemScheduler.hpp"
 #include "GameTypes.hpp"
 #include "Platform/Filesystem.hpp"
 #include "Platform/Platform.hpp"
-#include "Resources/MaterialCache.hpp"
-#include "Resources/MeshCache.hpp"
-#include "Resources/TextureCache.hpp"
-#include "Renderer/RendererFrontend.hpp"
+#include "Renderer/GameRenderer.hpp"
+#include "Core/EngineContext.hpp"
 
 namespace flatearth {
 
@@ -31,11 +32,12 @@ private:
   event::EventManager _eventManager;
   input::InputManager _inputManager;
   platform::FileSystem _filesystem;
-  renderer::FrontendRenderer _frontendRenderer;
-  resources::TextureCache _textureCache;
-  resources::MaterialCache _materialCache;
-  resources::MeshCache _meshCache;
+  assets::AssetManager _assetManager;
+  ecs::SystemScheduler _scheduler;
+  ecs::Registry _registry;
+  renderer::GameRenderer _renderer;
   FePtr<event::IEventListener> _engineListener;
+  EngineContext _ctx;
 };
 
 } // namespace flatearth

--- a/engine/src/Core/EngineContext.hpp
+++ b/engine/src/Core/EngineContext.hpp
@@ -1,0 +1,27 @@
+#ifndef _FLATEARTH_ENGINE_CORE_ENGINE_CONTEXT_HPP
+#define _FLATEARTH_ENGINE_CORE_ENGINE_CONTEXT_HPP
+
+#include "Assets/AssetManager.hpp"
+#include "Core/FeMemory.hpp"
+#include "Core/Input.hpp"
+#include "ECS/Registry.hpp"
+
+namespace flatearth {
+
+struct EngineContext {
+  assets::AssetManager &assetManager;
+  memory::MemoryManager &memoryManager;
+  input::InputManager &inputManager;
+  ecs::Registry &registry;
+
+  explicit EngineContext(memory::MemoryManager &memManager,
+                         assets::AssetManager &assetManager,
+                         input::InputManager &inputManager,
+                         ecs::Registry &registry)
+      : assetManager(assetManager), memoryManager(memManager), inputManager(inputManager),
+        registry(registry) {}
+};
+
+} // namespace flatearth
+
+#endif // _FLATEARTH_ENGINE_CORE_ENGINE_CONTEXT_HPP

--- a/engine/src/Core/EngineListener.cc
+++ b/engine/src/Core/EngineListener.cc
@@ -1,16 +1,16 @@
 #include "EngineListener.hpp"
 
 #include "Core/Logger.hpp"
-#include "Renderer/RendererFrontend.hpp"
+#include "Renderer/GameRenderer.hpp"
 
 namespace flatearth {
 
 const char *KeyToString(input::Keys key);
 
 EngineListener::EngineListener(event::EventManager &eventManager,
-                               ApplicationState &appState,
-                               renderer::FrontendRenderer &renderer)
-    : _eventManager(eventManager), _appState(appState), _frontendRenderer(renderer) {
+                               renderer::GameRenderer &renderer,
+                               ApplicationState &appState)
+    : _eventManager(eventManager), _appState(appState), _renderer(renderer) {
 }
 
 EngineListener::~EngineListener() {
@@ -106,7 +106,7 @@ FeExpect<bool, Error> EngineListener::OnResize(const event::EventDispatchContext
     return FeErr{Error("game failed to resize", ErrorType::GameResizeError)};
   }
 
-  auto res = _frontendRenderer.OnResize(width, height);
+  auto res = _renderer.FrontendReference().OnResize(width, height);
   if (!res.has_value()) {
     FLOG_ERROR("renderer failed to resize to {}x{}", width, height);
     return FeFalse;
@@ -128,11 +128,15 @@ FeExpect<bool, Error> EngineListener::OnKey(const event::EventDispatchContext &c
 
 FeExpect<bool, Error> EngineListener::OnEvent(const event::EventDispatchContext &ctx,
                                               const event::EventContext &eventCtx) {
-  if (ctx.code != event::SystemEventCode::ApplicationQuit) {
+  if (ctx.code == event::SystemEventCode::ApplicationQuit) {
+    _appState.isRunning = FeFalse;
+    return FeTrue;
+  }
+
+  if (ctx.code != event::SystemEventCode::FileLoaded) {
     return FeFalse;
   }
 
-  _appState.isRunning = FeFalse;
   return FeTrue;
 }
 

--- a/engine/src/Core/EngineListener.hpp
+++ b/engine/src/Core/EngineListener.hpp
@@ -3,17 +3,18 @@
 
 #include "ApplicationConfig.hpp"
 #include "Core/Event.hpp"
-#include "Renderer/RendererFrontend.hpp"
+#include "Renderer/GameRenderer.hpp"
 
 namespace flatearth {
 
 class EngineListener final : public event::ListenerAdapter {
 public:
   explicit EngineListener(event::EventManager &eventManager,
-                          ApplicationState &appState,
-                          renderer::FrontendRenderer &renderer);
+                          renderer::GameRenderer &renderer,
+                          ApplicationState &appState);
 
   ~EngineListener();
+
   // Inherited overrrides
   FeExpect<void, Error> Initialize() override;
   FeExpect<bool, Error> OnResize(const event::EventDispatchContext &ctx,
@@ -41,8 +42,8 @@ private:
 
 private:
   ApplicationState &_appState;
-  renderer::FrontendRenderer &_frontendRenderer;
   event::EventManager &_eventManager;
+  renderer::GameRenderer &_renderer;
 };
 
 } // namespace flatearth

--- a/engine/src/Core/Event.hpp
+++ b/engine/src/Core/Event.hpp
@@ -19,6 +19,7 @@ enum class SystemEventCode : uint16 {
   MouseMoved = 0x06,
   MouseWheel = 0x07,
   WindowResized = 0x08,
+  FileLoaded = 0x09,
 };
 
 inline constexpr uint16 ToUnderlying(SystemEventCode code) {

--- a/engine/src/ECS/Reflect/FieldType.hpp
+++ b/engine/src/ECS/Reflect/FieldType.hpp
@@ -17,11 +17,14 @@ enum class FieldType : uint8 {
   Uint32,
   Uint64,
   Float32,
-  Float64
+  Float64,
+  Vec2D,
 };
 
 constexpr uint8 FieldSize(FieldType t) {
   switch (t) {
+    case FieldType::Null:
+      return 0;
     case FieldType::Bool:
       return 1;
     case FieldType::Int8:
@@ -44,11 +47,15 @@ constexpr uint8 FieldSize(FieldType t) {
       return 4;
     case FieldType::Float64:
       return 8;
+    case FieldType::Vec2D:
+      return 8;
   }
 }
 
 constexpr const char *FieldTypeName(FieldType t) {
   switch (t) {
+    case FieldType::Null:
+      return "null";
     case FieldType::Bool:
       return "bool";
     case FieldType::Int8:
@@ -71,6 +78,8 @@ constexpr const char *FieldTypeName(FieldType t) {
       return "float32";
     case FieldType::Float64:
       return "float64";
+    case FieldType::Vec2D:
+      return "vec2d";
   }
   return "unknown";
 }

--- a/engine/src/ECS/Reflect/Reflect.hpp
+++ b/engine/src/ECS/Reflect/Reflect.hpp
@@ -31,12 +31,13 @@
       desc.authority = (Auth);                                 \
       desc.fields = {
 
+#define _FE_EXPAND(x) x
 #define _FE_REFLECT_GET3(_1, _2, NAME, ...) NAME
 #define _REFLECT_COMPONENT_2(Type, Auth) _REFLECT_COMPONENT_IMPL(Type, Auth)
 #define _REFLECT_COMPONENT_1(Type)       _REFLECT_COMPONENT_IMPL(Type, ::flatearth::ecs::reflect::Authority::Local)
 
 #define REFLECT_COMPONENT(...) \
-  _FE_REFLECT_GET3(__VA_ARGS__, _REFLECT_COMPONENT_2, _REFLECT_COMPONENT_1)(__VA_ARGS__)
+  _FE_EXPAND(_FE_REFLECT_GET3(__VA_ARGS__, _REFLECT_COMPONENT_2, _REFLECT_COMPONENT_1))(__VA_ARGS__)
 
 #define FIELD(name, ftype) {#name, static_cast<uint32>(offsetof(T, name)), ftype},
 

--- a/engine/src/ECS/Reflect/Serialize.cc
+++ b/engine/src/ECS/Reflect/Serialize.cc
@@ -12,6 +12,7 @@ using json = nlohmann::json;
 
 static json FieldToJson(const void *ptr, FieldType type) {
   switch (type) {
+    case FieldType::Null: return nullptr;
     case FieldType::Bool:    { bool    v; std::memcpy(&v, ptr, 1); return v; }
     case FieldType::Int8:    { int8_t  v; std::memcpy(&v, ptr, 1); return v; }
     case FieldType::Int16:   { int16_t v; std::memcpy(&v, ptr, 2); return v; }
@@ -23,6 +24,12 @@ static json FieldToJson(const void *ptr, FieldType type) {
     case FieldType::Uint64:  { uint64_t v; std::memcpy(&v, ptr, 8); return v; }
     case FieldType::Float32: { float  v; std::memcpy(&v, ptr, 4); return v; }
     case FieldType::Float64: { double v; std::memcpy(&v, ptr, 8); return v; }
+    case FieldType::Vec2D: {
+      float x, y;
+      std::memcpy(&x, ptr, 4);
+      std::memcpy(&y, static_cast<const char *>(ptr) + 4, 4);
+      return json{{"x", x}, {"y", y}};
+    }
   }
   return nullptr;
 }
@@ -32,6 +39,7 @@ static json FieldToJson(const void *ptr, FieldType type) {
 static bool FieldFromJson(void *ptr, FieldType type, const json &val) {
   try {
     switch (type) {
+      case FieldType::Null: return false;
       case FieldType::Bool:    { bool    v = val.get<bool>();    std::memcpy(ptr, &v, 1); return true; }
       case FieldType::Int8:    { int8_t  v = val.get<int8_t>();  std::memcpy(ptr, &v, 1); return true; }
       case FieldType::Int16:   { int16_t v = val.get<int16_t>(); std::memcpy(ptr, &v, 2); return true; }
@@ -43,6 +51,14 @@ static bool FieldFromJson(void *ptr, FieldType type, const json &val) {
       case FieldType::Uint64:  { uint64_t v = val.get<uint64_t>(); std::memcpy(ptr, &v, 8); return true; }
       case FieldType::Float32: { float  v = val.get<float>();  std::memcpy(ptr, &v, 4); return true; }
       case FieldType::Float64: { double v = val.get<double>(); std::memcpy(ptr, &v, 8); return true; }
+      case FieldType::Vec2D: {
+        if (!val.is_object()) return false;
+        float x = val.at("x").get<float>();
+        float y = val.at("y").get<float>();
+        std::memcpy(ptr, &x, 4);
+        std::memcpy(static_cast<char *>(ptr) + 4, &y, 4);
+        return true;
+      }
     }
   } catch (...) {
     return false;

--- a/engine/src/ECS/Registry.hpp
+++ b/engine/src/ECS/Registry.hpp
@@ -11,13 +11,13 @@ namespace flatearth::ecs {
 
 class Registry {
 public:
-  explicit Registry(memory::MemoryManager &memManager);
+  FEAPI explicit Registry(memory::MemoryManager &memManager);
 
-  EntityId Create();
+  FEAPI EntityId Create();
   void Destroy(EntityId id);
 
   template <typename T>
-  void Insert(EntityId id, const T &component) {
+  FEAPI void Insert(EntityId id, const T &component) {
     if (!_entityManager.IsAlive(id)) {
       return;
     }
@@ -27,7 +27,7 @@ public:
   }
 
   template <typename T>
-  void Remove(EntityId id) {
+  FEAPI void Remove(EntityId id) {
     if (!_entityManager.IsAlive(id)) {
       return;
     }
@@ -37,13 +37,13 @@ public:
   }
 
   template <typename T>
-  T &Get(EntityId id) {
+  FEAPI T &Get(EntityId id) {
     containers::SparseSet<T> *pSet = GetPool<T>();
     return pSet->Get(id);
   }
 
   template <typename T>
-  containers::SparseSet<T> *GetPool() {
+  FEAPI containers::SparseSet<T> *GetPool() {
     uint32 typeId = ComponentTypeId<T>::Value();
     FePtr<ISparseSetBase> *ppBase = _poolsMap.Retrieve(typeId);
     if (ppBase != nullptr) {
@@ -59,7 +59,7 @@ public:
   }
 
   template <typename T>
-  bool Has(EntityId id) const {
+  FEAPI bool Has(EntityId id) const {
     uint32 typeId = ComponentTypeId<T>::Value();
     const FePtr<ISparseSetBase> *ppBase = _poolsMap.Retrieve(typeId);
     if (ppBase == nullptr) return false;
@@ -67,7 +67,7 @@ public:
   }
 
   template <typename ...Ts>
-  View<Ts...> ViewOf() {
+  FEAPI View<Ts...> ViewOf() {
     return View<Ts...>(GetPool<Ts>()...);
   }
 

--- a/engine/src/ECS/Registry.hpp
+++ b/engine/src/ECS/Registry.hpp
@@ -17,7 +17,7 @@ public:
   void Destroy(EntityId id);
 
   template <typename T>
-  FEAPI void Insert(EntityId id, const T &component) {
+  void Insert(EntityId id, const T &component) {
     if (!_entityManager.IsAlive(id)) {
       return;
     }
@@ -27,7 +27,7 @@ public:
   }
 
   template <typename T>
-  FEAPI void Remove(EntityId id) {
+  void Remove(EntityId id) {
     if (!_entityManager.IsAlive(id)) {
       return;
     }
@@ -37,13 +37,13 @@ public:
   }
 
   template <typename T>
-  FEAPI T &Get(EntityId id) {
+  T &Get(EntityId id) {
     containers::SparseSet<T> *pSet = GetPool<T>();
     return pSet->Get(id);
   }
 
   template <typename T>
-  FEAPI containers::SparseSet<T> *GetPool() {
+  containers::SparseSet<T> *GetPool() {
     uint32 typeId = ComponentTypeId<T>::Value();
     FePtr<ISparseSetBase> *ppBase = _poolsMap.Retrieve(typeId);
     if (ppBase != nullptr) {
@@ -59,7 +59,7 @@ public:
   }
 
   template <typename T>
-  FEAPI bool Has(EntityId id) const {
+  bool Has(EntityId id) const {
     uint32 typeId = ComponentTypeId<T>::Value();
     const FePtr<ISparseSetBase> *ppBase = _poolsMap.Retrieve(typeId);
     if (ppBase == nullptr) return false;
@@ -67,7 +67,7 @@ public:
   }
 
   template <typename ...Ts>
-  FEAPI View<Ts...> ViewOf() {
+  View<Ts...> ViewOf() {
     return View<Ts...>(GetPool<Ts>()...);
   }
 

--- a/engine/src/GameTypes.hpp
+++ b/engine/src/GameTypes.hpp
@@ -1,21 +1,12 @@
 #ifndef _FLATEARTH_ENGINE_GAME_TYPES_HPP
 #define _FLATEARTH_ENGINE_GAME_TYPES_HPP
 
-#include "Core/Input.hpp"
 #include "Defines.hpp"
-#include "Renderer/RendererTypes.hpp"
 
 #include <functional>
 
-// TODO: remove this once EngineContext exists
-namespace flatearth::resources {
-class TextureCache;
-class MaterialCache;
-class MeshCache;
-} // namespace flatearth::resources
-
-namespace flatearth::renderer {
-class FrontendRenderer;
+namespace flatearth {
+struct EngineContext;
 }
 
 namespace flatearth {
@@ -30,30 +21,22 @@ public:
   std::function<bool(struct Game *gameInstance)> Load;
   std::function<void(struct Game *gameInstance)> Unload;
   std::function<bool(struct Game *gameInstance, float32 deltaTime)> Update;
-  std::function<bool(struct Game *gameInstance, renderer::RenderPacket &packet)> Render;
   std::function<bool(struct Game *gameInstance, uint32 width, uint32 height)> OnResize;
 
-  Game()
-      : Initialize(nullptr), Load(nullptr), Unload(nullptr), Update(nullptr), Render(nullptr),
+  explicit Game()
+      : Initialize(nullptr), Load(nullptr), Unload(nullptr), Update(nullptr),
         OnResize(nullptr), gameName(cGameName), windowStartWidth(scDefaultStartWidth),
         windowStartHeight(scDefaultStartHeight) {}
 
   Game(const string &name)
-      : Initialize(nullptr), Load(nullptr), Unload(nullptr), Update(nullptr), Render(nullptr),
+      : Initialize(nullptr), Load(nullptr), Unload(nullptr), Update(nullptr),
         OnResize(nullptr), gameName(name), windowStartWidth(scDefaultStartWidth),
         windowStartHeight(scDefaultStartHeight) {}
 
 public:
   string gameName;
   int32 windowStartPosX, windowStartPosY, windowStartWidth, windowStartHeight;
-
-  // TODO: these are only here so that we can get it up and running. REMOVE
-  // LATER
-  input::InputManager *pInputManager{nullptr};
-  resources::TextureCache *pTextureCache{nullptr};
-  resources::MaterialCache *pMaterialCache{nullptr};
-  resources::MeshCache *pMeshCache{nullptr};
-  renderer::FrontendRenderer *pRenderer{nullptr};
+  EngineContext *pCtx{nullptr};
 };
 
 } // namespace flatearth

--- a/engine/src/Renderer/GameRenderer.cc
+++ b/engine/src/Renderer/GameRenderer.cc
@@ -1,0 +1,73 @@
+#include "GameRenderer.hpp"
+
+#include "Platform/Filesystem.hpp"
+#include "Renderer/RendererFrontend.hpp"
+#include "Scene/Components/Camera2D.hpp"
+#include "Scene/Components/Sprite.hpp"
+#include "Scene/Components/Transform2D.hpp"
+
+namespace flatearth::renderer {
+
+GameRenderer::GameRenderer(ApplicationState *appState,
+                           memory::MemoryManager &memManager,
+                           ecs::Registry &reg,
+                           platform::FileSystem &fs)
+    : _memoryManager(memManager), _frontendRenderer(appState, memManager, fs), _registry(reg) {
+}
+
+FeExpect<bool, Error> GameRenderer::Initialize() {
+  return _frontendRenderer.Initialize();
+}
+
+FeExpect<bool, Error> GameRenderer::Draw(float32 deltaTime) {
+  using namespace scene;
+  using namespace ecs;
+
+  math::Mat4D view = math::Mat4D::Identity();
+  auto cameraView = _registry.ViewOf<Transform2D, Camera2D>();
+  for (auto [entity, transform, cam] : cameraView) {
+    // grabs first active camera
+    view = math::Mat4D::Scale(cam.zoom, cam.zoom, 1.0f) *
+           math::Mat4D::Translation(-transform.x, -transform.y, 0.0f) *
+           math::Mat4D::RotationZ(-transform.rotation);
+    break;
+  }
+
+  RenderPacket packet(_memoryManager);
+  packet.deltaTime = deltaTime;
+  packet.view = view;
+
+  View<Transform2D, Sprite> spriteView = _registry.ViewOf<Transform2D, Sprite>();
+  for (auto [entity, transform, sprite] : spriteView) {
+    resources::Mesh *pMesh = _frontendRenderer.GetMesh(sprite.meshHandle);
+    resources::Material *pMat = _frontendRenderer.GetMaterial(sprite.matHandle);
+    if (pMesh == nullptr || pMat == nullptr) {
+      continue;
+    }
+
+    math::Mat4D model = math::Mat4D::Translation(transform.x, transform.y, 0.0f) *
+                        math::Mat4D::RotationZ(transform.rotation) *
+                        math::Mat4D::Scale(transform.scaleX, transform.scaleY, 1.0f);
+    RenderObject object{
+        .geometryId = pMesh->id,
+        .model = model,
+        .uvOffset = sprite.uvOffset,
+        .uvScale = sprite.uvScale,
+        .layer = sprite.layer,
+        .pMaterial = pMat,
+    };
+    packet.objects.Push(object);
+  }
+
+  return _frontendRenderer.DrawFrame(&packet);
+}
+
+FrontendRenderer &GameRenderer::FrontendReference() {
+  return _frontendRenderer;
+}
+
+void GameRenderer::Shutdown() {
+  _frontendRenderer.Shutdown();
+}
+
+} // namespace flatearth::renderer

--- a/engine/src/Renderer/GameRenderer.hpp
+++ b/engine/src/Renderer/GameRenderer.hpp
@@ -1,0 +1,29 @@
+#ifndef _FLATEARTH_ENGINE_RENDERER_GAME_RENDERER_HPP
+#define _FLATEARTH_ENGINE_RENDERER_GAME_RENDERER_HPP
+
+#include "Core/FeMemory.hpp"
+#include "ECS/Registry.hpp"
+#include "Platform/Filesystem.hpp"
+#include "Renderer/RendererFrontend.hpp"
+namespace flatearth::renderer {
+
+class GameRenderer {
+public:
+  explicit GameRenderer(ApplicationState *pAppState, memory::MemoryManager &memManager,
+                              ecs::Registry &registry, platform::FileSystem &fs);
+
+  FeExpect<bool, Error> Initialize();
+  FeExpect<bool, Error> Draw(float32 deltaTime);
+  void Shutdown();
+
+  FrontendRenderer &FrontendReference();
+
+private:
+  renderer::FrontendRenderer _frontendRenderer;
+  memory::MemoryManager &_memoryManager;
+  ecs::Registry &_registry;
+};
+
+} // namespace flatearth::renderer
+
+#endif // _FLATEARTH_ENGINE_RENDERER_GAME_RENDERER_HPP

--- a/engine/src/Renderer/RendererFrontend.cc
+++ b/engine/src/Renderer/RendererFrontend.cc
@@ -18,11 +18,16 @@ FrontendRenderer::FrontendRenderer(ApplicationState *appState,
                                    memory::MemoryManager &memManager,
                                    platform::FileSystem &fs)
     : _applicationName(appState->appConfig.name), _memoryManager(memManager), _pAppState(appState),
-      _filesystem(fs) {
+      _filesystem(fs), _meshCache(memManager, *this), _materialCache(memManager, *this) {
 }
 
 FrontendRenderer::~FrontendRenderer() {
   FLOG_INFO("frontend renderer exited gracefully");
+}
+
+void FrontendRenderer::Shutdown() {
+  _meshCache.Shutdown();
+  _materialCache.Shutdown();
 }
 
 FeExpect<bool, Error> FrontendRenderer::Initialize() {
@@ -194,6 +199,31 @@ FeExpect<void, Error> FrontendRenderer::CreateMaterial(resources::Material *pMat
 
 FeExpect<void, Error> FrontendRenderer::DestroyMaterial(resources::Material *pMaterial) {
   return _rendererState.pActiveBackend->DestroyMaterial(pMaterial);
+}
+
+FeExpect<resources::MeshHandle, Error> FrontendRenderer::AcquireMesh(resources::MeshShape shape) {
+  return _meshCache.AcquireMesh(shape);
+}
+
+void FrontendRenderer::ReleaseMesh(resources::MeshHandle handle) {
+  _meshCache.Release(handle);
+}
+
+resources::Mesh *FrontendRenderer::GetMesh(resources::MeshHandle handle) {
+  return _meshCache.Get(handle);
+}
+
+FeExpect<resources::MaterialHandle, Error>
+FrontendRenderer::AcquireMaterial(const string &name, resources::Texture *pTexture) {
+  return _materialCache.AcquireMaterial(name, pTexture);
+}
+
+void FrontendRenderer::ReleaseMaterial(resources::MaterialHandle handle) {
+  _materialCache.Release(handle);
+}
+
+resources::Material *FrontendRenderer::GetMaterial(resources::MaterialHandle handle) {
+  return _materialCache.Get(handle);
 }
 
 FeExpect<void, Error> FrontendRenderer::MakeBackends() {

--- a/engine/src/Renderer/RendererFrontend.hpp
+++ b/engine/src/Renderer/RendererFrontend.hpp
@@ -6,6 +6,8 @@
 #include "Defines.hpp"
 #include "Platform/Filesystem.hpp"
 #include "Renderer/RendererInterface.hpp"
+#include "Resources/MaterialCache.hpp"
+#include "Resources/MeshCache.hpp"
 #include "Resources/ResourceTypes.hpp"
 
 namespace flatearth::renderer {
@@ -52,6 +54,19 @@ public:
                                              const uint32 *pIndices);
   FEAPI FeExpect<void, Error> DestroyGeometry(uint32 id);
 
+  // Mesh cache public API
+  FEAPI FeExpect<resources::MeshHandle, Error> AcquireMesh(resources::MeshShape shape);
+  FEAPI void ReleaseMesh(resources::MeshHandle handle);
+  FEAPI resources::Mesh *GetMesh(resources::MeshHandle handle);
+
+  // Material cache public API
+  FEAPI FeExpect<resources::MaterialHandle, Error> AcquireMaterial(const string &name,
+                                                                    resources::Texture *pTexture);
+  FEAPI void ReleaseMaterial(resources::MaterialHandle handle);
+  FEAPI resources::Material *GetMaterial(resources::MaterialHandle handle);
+
+  FEAPI void Shutdown();
+
 private:
   FeExpect<void, Error> MakeBackends();
 
@@ -63,6 +78,8 @@ private:
   ApplicationState *_pAppState;
   string _applicationName;
   platform::FileSystem &_filesystem;
+  resources::MeshCache _meshCache;
+  resources::MaterialCache _materialCache;
 };
 
 } // namespace flatearth::renderer

--- a/engine/src/Resources/MaterialCache.cc
+++ b/engine/src/Resources/MaterialCache.cc
@@ -1,34 +1,33 @@
 #include "MaterialCache.hpp"
 
 #include "Core/Logger.hpp"
+#include "Renderer/RendererFrontend.hpp"
 
 namespace flatearth::resources {
 
 MaterialCache::MaterialCache(memory::MemoryManager &memManager,
-                             renderer::FrontendRenderer &renderer,
-                             TextureCache &textureCache)
-    : ResourceCache(memManager), _renderer(renderer), _textureCache(textureCache) {}
+                             renderer::FrontendRenderer &renderer)
+    : ResourceCache(memManager), _renderer(renderer) {}
 
 FeExpect<MaterialHandle, Error> MaterialCache::AcquireMaterial(const string &name,
-                                                               TextureHandle texHandle) {
-  _pendingTexHandle = texHandle;
+                                                               Texture *pTexture) {
+  _pendingTexture = pTexture;
   return this->ProtectedAcquire(name);
 }
 
 FeExpect<void, Error> MaterialCache::Create(Material *pMaterial,
                                             uint32 handle,
                                             const string &name) {
-  Texture *pTexture = _textureCache.Get(_pendingTexHandle);
-  if (pTexture == nullptr) {
-    FLOG_ERROR("failed to resolve texture handle {} for material '{}'", _pendingTexHandle, name);
-    return FeErr{Error("texture handle could not be resolved", ErrorType::NullptrException)};
+  if (_pendingTexture == nullptr) {
+    FLOG_ERROR("nullptr texture passed for material '{}'", name);
+    return FeErr{Error("texture pointer is null", ErrorType::NullptrException)};
   }
 
   pMaterial->id = handle;
   pMaterial->name = name;
-  pMaterial->texHandle = _pendingTexHandle;
+  pMaterial->texHandle = _pendingTexture->id;
 
-  return _renderer.CreateMaterial(pMaterial, pTexture);
+  return _renderer.CreateMaterial(pMaterial, _pendingTexture);
 }
 
 FeExpect<void, Error> MaterialCache::Destroy(Material *pMaterial) {

--- a/engine/src/Resources/MaterialCache.hpp
+++ b/engine/src/Resources/MaterialCache.hpp
@@ -2,21 +2,20 @@
 #define _FLATEARTH_ENGINE_RESOURCES_MATERIAL_CACHE_HPP
 
 #include "Core/FeMemory.hpp"
-#include "Renderer/RendererFrontend.hpp"
 #include "Resources/ResourceCache.hpp"
 #include "Resources/ResourceTypes.hpp"
-#include "Resources/TextureCache.hpp"
+
+namespace flatearth::renderer { class FrontendRenderer; }
 
 namespace flatearth::resources {
 
 class MaterialCache : public ResourceCache<Material> {
 public:
   FEAPI explicit MaterialCache(memory::MemoryManager &memManager,
-                               renderer::FrontendRenderer &renderer,
-                               TextureCache &textureCache);
+                               renderer::FrontendRenderer &renderer);
 
-  FEAPI FeExpect<MaterialHandle, Error> AcquireMaterial(const string &name,
-                                                        TextureHandle texHandle);
+  // Caller resolves TextureHandle → Texture* before calling
+  FEAPI FeExpect<MaterialHandle, Error> AcquireMaterial(const string &name, Texture *pTexture);
 
 protected:
   FeExpect<void, Error> Create(Material *pMaterial, uint32 handle, const string &name) override;
@@ -24,8 +23,7 @@ protected:
 
 private:
   renderer::FrontendRenderer &_renderer;
-  TextureCache &_textureCache;
-  TextureHandle _pendingTexHandle{0};
+  Texture *_pendingTexture{nullptr};
 };
 
 } // namespace flatearth::resources

--- a/engine/src/Resources/MeshCache.cc
+++ b/engine/src/Resources/MeshCache.cc
@@ -2,6 +2,7 @@
 
 #include "Core/Logger.hpp"
 #include "Math/MathTypes.hpp"
+#include "Renderer/RendererFrontend.hpp"
 
 #include <cmath>
 #include <vector>

--- a/engine/src/Resources/MeshCache.hpp
+++ b/engine/src/Resources/MeshCache.hpp
@@ -2,9 +2,10 @@
 #define _FLATEARTH_ENGINE_RESOURCES_MESH_CACHE_HPP
 
 #include "Core/FeMemory.hpp"
-#include "Renderer/RendererFrontend.hpp"
 #include "Resources/ResourceCache.hpp"
 #include "Resources/ResourceTypes.hpp"
+
+namespace flatearth::renderer { class FrontendRenderer; }
 
 namespace flatearth::resources {
 

--- a/engine/src/Resources/ResourceTypes.hpp
+++ b/engine/src/Resources/ResourceTypes.hpp
@@ -9,7 +9,7 @@ using TextureHandle = uint32;
 using MaterialHandle = uint32;
 using MeshHandle = uint32;
 
-enum class MeshShape {
+enum class MeshShape : uint16 {
   Quad,
   Circle,
   Capsule2D,

--- a/engine/src/Resources/TextureCache.cc
+++ b/engine/src/Resources/TextureCache.cc
@@ -7,16 +7,26 @@
 
 namespace flatearth::resources {
 
-TextureCache::TextureCache(memory::MemoryManager &memManager,
-                           renderer::FrontendRenderer &renderer,
-                           platform::FileSystem &fs)
-    : ResourceCache(memManager), _renderer(renderer), _fs(fs) {
+TextureCache::TextureCache(memory::MemoryManager &memManager, platform::FileSystem &fs)
+    : ResourceCache(memManager), _fs(fs) {
+}
+
+void TextureCache::Initialize(renderer::FrontendRenderer *pRenderer) {
+  if (pRenderer == nullptr) {
+    return;
+  }
+
+  _pRenderer = pRenderer;
 }
 
 FeExpect<TextureHandle, Error> TextureCache::AcquireTexture(const string &path,
                                                             TextureFilter filter) {
   _filterToUse = filter;
   return this->ProtectedAcquire(path);
+}
+
+bool TextureCache::Initialized() const {
+  return _pRenderer != nullptr;
 }
 
 FeExpect<void, Error>
@@ -61,7 +71,7 @@ TextureCache::Create(Texture *pTexture, uint32 /*handle*/, const string &path) {
   }
 
   bool hasTransparency = channels == 4;
-  auto texRes = _renderer.CreateTexture(
+  auto texRes = _pRenderer->CreateTexture(
       path, false, width, height, 4, pPixels, hasTransparency, pTexture, _filterToUse);
 
   stbi_image_free(pPixels);
@@ -75,7 +85,7 @@ TextureCache::Create(Texture *pTexture, uint32 /*handle*/, const string &path) {
 }
 
 FeExpect<void, Error> TextureCache::Destroy(Texture *pTexture) {
-  return _renderer.DestroyTexture(pTexture);
+  return _pRenderer->DestroyTexture(pTexture);
 }
 
 } // namespace flatearth::resources

--- a/engine/src/Resources/TextureCache.hpp
+++ b/engine/src/Resources/TextureCache.hpp
@@ -12,11 +12,14 @@ namespace flatearth::resources {
 class TextureCache : public ResourceCache<Texture> {
 public:
   FEAPI explicit TextureCache(memory::MemoryManager &memManager,
-                              renderer::FrontendRenderer &renderer,
                               platform::FileSystem &fs);
+
+  void Initialize(renderer::FrontendRenderer *pRenderer);
 
   FEAPI FeExpect<TextureHandle, Error>
   AcquireTexture(const string &path, TextureFilter filter = TextureFilter::Nearest);
+
+  bool Initialized() const;
 
 protected:
   FeExpect<void, Error> Create(Texture *pTexture, uint32 handle, const string &path) override;
@@ -24,8 +27,8 @@ protected:
 
 private:
   TextureFilter _filterToUse{TextureFilter::Nearest};
-  renderer::FrontendRenderer &_renderer;
   platform::FileSystem &_fs;
+  renderer::FrontendRenderer *_pRenderer;
 };
 
 } // namespace flatearth::resources

--- a/engine/src/Scene/Components/Camera2D.cc
+++ b/engine/src/Scene/Components/Camera2D.cc
@@ -1,0 +1,12 @@
+#include "Camera2D.hpp"
+
+#include "ECS/Reflect/FieldType.hpp"
+#include "ECS/Reflect/Reflect.hpp"
+
+namespace flatearth::scene {
+
+REFLECT_COMPONENT(Camera2D)
+FIELD(zoom, ecs::reflect::FieldType::Float32)
+END_REFLECT
+
+} // namespace flatearth::scene

--- a/engine/src/Scene/Components/Camera2D.hpp
+++ b/engine/src/Scene/Components/Camera2D.hpp
@@ -1,0 +1,14 @@
+#ifndef _FLATEARTH_ENGINE_SCENE_COMPONENTS_CAMERA2D_HPP
+#define _FLATEARTH_ENGINE_SCENE_COMPONENTS_CAMERA2D_HPP
+
+#include "Defines.hpp"
+
+namespace flatearth::scene {
+
+struct Camera2D {
+  float32 zoom{1.0f};
+};
+
+}
+
+#endif // _FLATEARTH_ENGINE_SCENE_COMPONENTS_CAMERA2D_HPP

--- a/engine/src/Scene/Components/Sprite.cc
+++ b/engine/src/Scene/Components/Sprite.cc
@@ -1,0 +1,14 @@
+#include "Sprite.hpp"
+
+#include "ECS/Reflect/Reflect.hpp"
+
+namespace flatearth::scene {
+
+REFLECT_COMPONENT(Sprite)
+FIELD(layer, ecs::reflect::FieldType::Uint32)
+FIELD(meshShape, ecs::reflect::FieldType::Uint16)
+FIELD(uvOffset, ecs::reflect::FieldType::Vec2D)
+FIELD(uvScale, ecs::reflect::FieldType::Vec2D)
+END_REFLECT
+
+} // namespace flatearth::scene

--- a/engine/src/Scene/Components/Sprite.hpp
+++ b/engine/src/Scene/Components/Sprite.hpp
@@ -1,0 +1,26 @@
+#ifndef _FLATEARTH_ENGINE_SCENE_COMPONENTS_SPRITE_HPP
+#define _FLATEARTH_ENGINE_SCENE_COMPONENTS_SPRITE_HPP
+
+#include "Defines.hpp"
+#include "Math/Vector2D.hpp"
+#include "Renderer/RendererTypes.hpp"
+#include "Resources/ResourceTypes.hpp"
+
+namespace flatearth::scene {
+
+struct Sprite {
+  renderer::RenderLayer layer{renderer::RenderLayer::Entities};
+  resources::MeshShape meshShape{resources::MeshShape::Quad};
+  math::Vec2D uvOffset{0.0f, 0.0f};
+  math::Vec2D uvScale{1.0f, 1.0f};
+
+  // Runtime only, not reflected
+  bool dirty{FeTrue};
+  resources::TextureHandle texHandle{0};
+  resources::MaterialHandle matHandle{0};
+  resources::MeshHandle meshHandle{0};
+};
+
+} // namespace flatearth::scene
+
+#endif // _FLATEARTH_ENGINE_SCENE_COMPONENTS_SPRITE_HPP

--- a/engine/src/Scene/Components/Transform2D.hpp
+++ b/engine/src/Scene/Components/Transform2D.hpp
@@ -14,6 +14,8 @@ struct Transform2D {
   float32 rotation{0.0f};
   float32 scaleX{1.0f};
   float32 scaleY{1.0f};
+
+  // Runtime, not reflected
   ecs::EntityId parent{cNullEntity};
   bool dirty{FeTrue};
 };

--- a/engine/src/Scene/Systems/SpriteSystem.cc
+++ b/engine/src/Scene/Systems/SpriteSystem.cc
@@ -1,0 +1,30 @@
+#include "SpriteSystem.hpp"
+#include "Scene/Components/Children.hpp"
+#include "Scene/Components/Sprite.hpp"
+
+namespace flatearth::systems {
+
+void SpriteSystem::Update(ecs::Registry &registry, float32 deltaTime) {
+  using namespace scene;
+  ecs::View<Sprite> view = registry.ViewOf<Sprite>();
+
+  for (auto [entity, sprite] : view) {
+    if (!sprite.dirty) {
+      continue;
+    }
+
+    if (!registry.Has<Children>(entity)) {
+      continue;
+    }
+
+    Children &children = registry.Get<Children>(entity);
+    for (uint8 i = 0; i < children.count; i++) {
+      ecs::EntityId child = children.ids[i];
+      if (registry.Has<Sprite>(child)) {
+        registry.Get<Sprite>(child).dirty = FeTrue;
+      }
+    }
+  }
+}
+
+}

--- a/engine/src/Scene/Systems/SpriteSystem.hpp
+++ b/engine/src/Scene/Systems/SpriteSystem.hpp
@@ -1,0 +1,15 @@
+#ifndef _FLATEARTH_ENGINE_SCENE_SYSTEMS_SPRITE_SYSTEM_HPP
+#define _FLATEARTH_ENGINE_SCENE_SYSTEMS_SPRITE_SYSTEM_HPP
+
+#include "ECS/SystemInterface.hpp"
+
+namespace flatearth::systems {
+
+class SpriteSystem : public ecs::ISystem {
+public:
+  void Update(ecs::Registry &registry, float32 deltaTime) override;
+};
+
+}
+
+#endif // _FLATEARTH_ENGINE_SCENE_SYSTEMS_SPRITE_SYSTEM_HPP

--- a/testbed/src/Entrypoint.cc
+++ b/testbed/src/Entrypoint.cc
@@ -12,7 +12,6 @@ bool CreateGame(flatearth::Game *pGame) {
   pGame->Load = GameTest::GameLoad;
   pGame->Unload = GameTest::GameUnload;
   pGame->Update = GameTest::GameUpdate;
-  pGame->Render = GameTest::GameRender;
   pGame->OnResize = GameTest::GameOnResize;
   return true;
 }

--- a/testbed/src/Game.cc
+++ b/testbed/src/Game.cc
@@ -4,94 +4,173 @@
 #include <Core/Input.hpp>
 #include <Core/Logger.hpp>
 #include <Defines.hpp>
+#include <Math/FeMath.hpp>
 #include <Scene/Components/Camera2D.hpp>
 #include <Scene/Components/Transform2D.hpp>
 
 namespace flatearth::testbed {
 
+// ── field dimensions (orthographic: x in [-aspect,aspect], y in [-1,1]) ─────
+static constexpr float32 cAspect       = 1280.0f / 720.0f;
+static constexpr float32 cPaddleX      = 1.5f;
+static constexpr float32 cPaddleScaleX = 0.08f;
+static constexpr float32 cPaddleScaleY = 0.35f;
+static constexpr float32 cPaddleHalfW  = cPaddleScaleX * 0.5f;
+static constexpr float32 cPaddleHalfH  = cPaddleScaleY * 0.5f;
+static constexpr float32 cBallScale    = 0.08f;
+static constexpr float32 cBallHalf     = cBallScale * 0.5f;
+static constexpr float32 cWallY        = 1.0f;
+static constexpr float32 cPlayerSpeed  = 2.5f;
+static constexpr float32 cAISpeed      = 2.2f;
+static constexpr float32 cBallInitVx   = 1.5f;
+static constexpr float32 cBallInitVy   = 0.8f;
+static constexpr float32 cSpeedupRate  = 1.05f;
+
 GameState GameTest::_state = GameState{};
 
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+static inline float32 Clamp(float32 v, float32 lo, float32 hi) {
+  return v < lo ? lo : (v > hi ? hi : v);
+}
+
+static inline bool AABBOverlap(float32 ax, float32 ay, float32 ahw, float32 ahh,
+                                float32 bx, float32 by, float32 bhw, float32 bhh) {
+  return math::Abs(ax - bx) < ahw + bhw && math::Abs(ay - by) < ahh + bhh;
+}
+
+void GameTest::ResetBall(flatearth::Game *gameInstance) {
+  EngineContext &ctx = *gameInstance->pCtx;
+  auto &t = ctx.registry.Get<scene::Transform2D>(_state.ballEntity);
+  t.x = 0.0f;
+  t.y = 0.0f;
+  t.dirty = FeTrue;
+
+  _state.serveRight = !_state.serveRight;
+  _state.ballVx = _state.serveRight ? cBallInitVx : -cBallInitVx;
+  _state.ballVy = cBallInitVy;
+}
+
+// ── lifecycle ─────────────────────────────────────────────────────────────────
+
 bool GameTest::GameInitialize(flatearth::Game *gameInstance) {
-  gameInstance->windowStartWidth = 1280;
+  gameInstance->windowStartWidth  = 1280;
   gameInstance->windowStartHeight = 720;
-  gameInstance->windowStartPosX = 100;
-  gameInstance->windowStartPosY = 100;
-  gameInstance->gameName = "Testbed";
+  gameInstance->windowStartPosX   = 100;
+  gameInstance->windowStartPosY   = 100;
+  gameInstance->gameName          = "Pong";
   return FeTrue;
 }
 
 bool GameTest::GameLoad(flatearth::Game *gameInstance) {
   EngineContext &ctx = *gameInstance->pCtx;
 
-  // Camera entity
+  // Camera — static, centered
   _state.cameraEntity = ctx.registry.Create();
   ctx.registry.Insert(_state.cameraEntity, scene::Transform2D{});
-  ctx.registry.Insert(_state.cameraEntity, scene::Camera2D{.zoom = 0.5f});
+  ctx.registry.Insert(_state.cameraEntity, scene::Camera2D{});
 
-  // Quad sprite
-  auto quadRes = ctx.assetManager.LoadSprite("assets/textures/texture.jpg",
-                                             resources::MeshShape::Quad);
-  if (!quadRes.has_value()) {
-    FLOG_ERROR("failed to load quad sprite");
+  // Paddle sprite (shared by both paddles)
+  auto paddleRes = ctx.assetManager.LoadSprite("assets/textures/texture.jpg",
+                                               resources::MeshShape::Quad);
+  if (!paddleRes.has_value()) {
+    FLOG_ERROR("failed to load paddle sprite");
     return FeFalse;
   }
-  _state.quadSprite = quadRes.value();
-  _state.quadEntity = ctx.registry.Create();
-  ctx.registry.Insert(_state.quadEntity, scene::Transform2D{});
-  ctx.registry.Insert(_state.quadEntity, _state.quadSprite);
+  _state.paddleSprite = paddleRes.value();
 
-  // Circle sprite
-  auto circleRes = ctx.assetManager.LoadSprite("assets/textures/texture.jpg",
-                                               resources::MeshShape::Circle);
-  if (!circleRes.has_value()) {
-    FLOG_ERROR("failed to load circle sprite");
+  // Player paddle — left side
+  _state.playerEntity = ctx.registry.Create();
+  ctx.registry.Insert(_state.playerEntity,
+      scene::Transform2D{-cPaddleX, 0.0f, 0.0f, cPaddleScaleX, cPaddleScaleY});
+  ctx.registry.Insert(_state.playerEntity, _state.paddleSprite);
+
+  // AI paddle — right side (same sprite, different entity)
+  _state.aiEntity = ctx.registry.Create();
+  ctx.registry.Insert(_state.aiEntity,
+      scene::Transform2D{cPaddleX, 0.0f, 0.0f, cPaddleScaleX, cPaddleScaleY});
+  ctx.registry.Insert(_state.aiEntity, _state.paddleSprite);
+
+  // Ball sprite
+  auto ballRes = ctx.assetManager.LoadSprite("assets/textures/rugtexture.jpg",
+                                             resources::MeshShape::Circle);
+  if (!ballRes.has_value()) {
+    FLOG_ERROR("failed to load ball sprite");
     return FeFalse;
   }
-  _state.circleSprite = circleRes.value();
-  _state.circleEntity = ctx.registry.Create();
-  ctx.registry.Insert(_state.circleEntity, scene::Transform2D{0.0f, 1.2f});
-  ctx.registry.Insert(_state.circleEntity, _state.circleSprite);
-
-  // Capsule sprite
-  auto capsuleRes = ctx.assetManager.LoadSprite("assets/textures/rugtexture.jpg",
-                                                resources::MeshShape::Capsule2D);
-  if (!capsuleRes.has_value()) {
-    FLOG_ERROR("failed to load capsule sprite");
-    return FeFalse;
-  }
-  _state.capsuleSprite = capsuleRes.value();
-  _state.capsuleEntity = ctx.registry.Create();
-  ctx.registry.Insert(_state.capsuleEntity, scene::Transform2D{-1.2f, 0.0f});
-  ctx.registry.Insert(_state.capsuleEntity, _state.capsuleSprite);
+  _state.ballSprite = ballRes.value();
+  _state.ballEntity = ctx.registry.Create();
+  ctx.registry.Insert(_state.ballEntity,
+      scene::Transform2D{0.0f, 0.0f, 0.0f, cBallScale, cBallScale});
+  ctx.registry.Insert(_state.ballEntity, _state.ballSprite);
 
   return FeTrue;
 }
+
+// ── update ────────────────────────────────────────────────────────────────────
 
 bool GameTest::GameUpdate(flatearth::Game *gameInstance, float32 deltaTime) {
   if (!gameInstance->pCtx) return FeFalse;
   EngineContext &ctx = *gameInstance->pCtx;
   input::InputManager &input = ctx.inputManager;
 
-  const float32 dy = 3.0f * deltaTime;
-  const float32 dx = 3.0f * deltaTime;
-  const float32 zoomFactor = 1.0f + 1.5f * deltaTime;
+  auto &player = ctx.registry.Get<scene::Transform2D>(_state.playerEntity);
+  auto &ai     = ctx.registry.Get<scene::Transform2D>(_state.aiEntity);
+  auto &ball   = ctx.registry.Get<scene::Transform2D>(_state.ballEntity);
 
-  auto &camTransform = ctx.registry.Get<scene::Transform2D>(_state.cameraEntity);
-  auto &camComp = ctx.registry.Get<scene::Camera2D>(_state.cameraEntity);
-  if (input.IsKeyDown(input::Keys::KEY_W)) { camTransform.y += dy; camTransform.dirty = FeTrue; }
-  if (input.IsKeyDown(input::Keys::KEY_S)) { camTransform.y -= dy; camTransform.dirty = FeTrue; }
-  if (input.IsKeyDown(input::Keys::KEY_A)) { camTransform.x += dx; camTransform.dirty = FeTrue; }
-  if (input.IsKeyDown(input::Keys::KEY_D)) { camTransform.x -= dx; camTransform.dirty = FeTrue; }
-  if (input.IsKeyDown(input::Keys::KEY_Z)) { camComp.zoom *= zoomFactor; }
-  if (input.IsKeyDown(input::Keys::KEY_X)) { camComp.zoom /= zoomFactor; }
+  // ── player input ──────────────────────────────────────────────────────────
+  if (input.IsKeyDown(input::Keys::KEY_W)) {
+    player.y = Clamp(player.y + cPlayerSpeed * deltaTime,
+                     -(cWallY - cPaddleHalfH), cWallY - cPaddleHalfH);
+    player.dirty = FeTrue;
+  }
+  if (input.IsKeyDown(input::Keys::KEY_S)) {
+    player.y = Clamp(player.y - cPlayerSpeed * deltaTime,
+                     -(cWallY - cPaddleHalfH), cWallY - cPaddleHalfH);
+    player.dirty = FeTrue;
+  }
 
-  _state.angle  += deltaTime * 1.5f;
-  _state.angle2 -= deltaTime * 2.0f;
-  _state.angle3 += deltaTime * 1.0f;
+  // ── AI paddle tracks ball ─────────────────────────────────────────────────
+  float32 aiDiff = ball.y - ai.y;
+  float32 aiMove = Clamp(aiDiff, -cAISpeed * deltaTime, cAISpeed * deltaTime);
+  ai.y = Clamp(ai.y + aiMove, -(cWallY - cPaddleHalfH), cWallY - cPaddleHalfH);
+  ai.dirty = FeTrue;
 
-  ctx.registry.Get<scene::Transform2D>(_state.quadEntity).rotation    = _state.angle;
-  ctx.registry.Get<scene::Transform2D>(_state.circleEntity).rotation  = _state.angle2;
-  ctx.registry.Get<scene::Transform2D>(_state.capsuleEntity).rotation = _state.angle3;
+  // ── move ball ─────────────────────────────────────────────────────────────
+  ball.x += _state.ballVx * deltaTime;
+  ball.y += _state.ballVy * deltaTime;
+  ball.dirty = FeTrue;
+
+  // ── wall bounce (top / bottom) ────────────────────────────────────────────
+  if (ball.y + cBallHalf >= cWallY) {
+    ball.y = cWallY - cBallHalf;
+    _state.ballVy = -math::Abs(_state.ballVy);
+  } else if (ball.y - cBallHalf <= -cWallY) {
+    ball.y = -cWallY + cBallHalf;
+    _state.ballVy = math::Abs(_state.ballVy);
+  }
+
+  // ── paddle collision ──────────────────────────────────────────────────────
+  auto PaddleHit = [&](scene::Transform2D &paddle) {
+    if (!AABBOverlap(ball.x, ball.y, cBallHalf, cBallHalf,
+                     paddle.x, paddle.y, cPaddleHalfW, cPaddleHalfH)) return;
+
+    float32 relHit = (ball.y - paddle.y) / cPaddleHalfH;
+    _state.ballVx  = -_state.ballVx * cSpeedupRate;
+    _state.ballVy  = Clamp(_state.ballVy + relHit * 1.5f, -3.0f, 3.0f);
+
+    // push ball out of paddle to prevent tunnelling
+    ball.x = paddle.x + ((_state.ballVx > 0) ? 1.0f : -1.0f) * (cPaddleHalfW + cBallHalf);
+  };
+
+  if (_state.ballVx < 0) PaddleHit(player);
+  else                    PaddleHit(ai);
+
+  // ── out of bounds → reset ─────────────────────────────────────────────────
+  if (ball.x > cAspect + cBallHalf || ball.x < -(cAspect + cBallHalf)) {
+    FLOG_INFO("point scored — resetting ball");
+    ResetBall(gameInstance);
+  }
 
   return FeTrue;
 }
@@ -99,9 +178,8 @@ bool GameTest::GameUpdate(flatearth::Game *gameInstance, float32 deltaTime) {
 void GameTest::GameUnload(flatearth::Game *gameInstance) {
   if (!gameInstance->pCtx) return;
   EngineContext &ctx = *gameInstance->pCtx;
-  ctx.assetManager.ReleaseSprite(_state.quadSprite);
-  ctx.assetManager.ReleaseSprite(_state.circleSprite);
-  ctx.assetManager.ReleaseSprite(_state.capsuleSprite);
+  ctx.assetManager.ReleaseSprite(_state.paddleSprite);
+  ctx.assetManager.ReleaseSprite(_state.ballSprite);
 }
 
 bool GameTest::GameOnResize(flatearth::Game *, uint32, uint32) {

--- a/testbed/src/Game.cc
+++ b/testbed/src/Game.cc
@@ -1,27 +1,14 @@
 #include "Game.hpp"
 
+#include <Core/EngineContext.hpp>
 #include <Core/Input.hpp>
 #include <Core/Logger.hpp>
 #include <Defines.hpp>
-#include <Math/FeMath.hpp>
-#include <Renderer/RendererFrontend.hpp>
-#include <Resources/MaterialCache.hpp>
-#include <Resources/MeshCache.hpp>
-#include <Resources/TextureCache.hpp>
-#include <Renderer/RendererTypes.hpp>
+#include <Scene/Components/Transform2D.hpp>
 
 namespace flatearth::testbed {
 
 GameState GameTest::_state = GameState{};
-
-static void RecalculateCameraView(GameState &state) {
-  if (!state.cameraViewDirty)
-    return;
-
-  state.view = math::Mat4D::Translation(-state.cameraPosition.x(), -state.cameraPosition.y(), 0.0f);
-
-  state.cameraViewDirty = FeFalse;
-}
 
 bool GameTest::GameInitialize(flatearth::Game *gameInstance) {
   gameInstance->windowStartWidth = 1280;
@@ -29,138 +16,87 @@ bool GameTest::GameInitialize(flatearth::Game *gameInstance) {
   gameInstance->windowStartPosX = 100;
   gameInstance->windowStartPosY = 100;
   gameInstance->gameName = "Testbed";
-
-  _state.cameraPosition = math::Vec3D(0.0f, 0.0f, -5.0f);
-  _state.cameraEuler = math::Vec3D::Zero();
-  _state.view = math::Mat4D::Identity();
-  _state.cameraViewDirty = FeTrue;
   return FeTrue;
 }
 
 bool GameTest::GameLoad(flatearth::Game *gameInstance) {
-  auto meshRes = gameInstance->pMeshCache->AcquireMesh(resources::MeshShape::Quad);
-  if (!meshRes.has_value()) {
-    FLOG_ERROR("failed to acquire quad mesh");
+  EngineContext &ctx = *gameInstance->pCtx;
+
+  // Camera entity
+  _state.cameraEntity = ctx.registry.Create();
+  ctx.registry.Insert(_state.cameraEntity, scene::Transform2D{});
+  ctx.registry.Insert(_state.cameraEntity, scene::Camera2D{});
+
+  // Quad sprite
+  auto quadRes = ctx.assetManager.LoadSprite("assets/textures/texture.jpg",
+                                             resources::MeshShape::Quad);
+  if (!quadRes.has_value()) {
+    FLOG_ERROR("failed to load quad sprite");
     return FeFalse;
   }
-  _state.quadMesh = meshRes.value();
+  _state.quadSprite = quadRes.value();
+  _state.quadEntity = ctx.registry.Create();
+  ctx.registry.Insert(_state.quadEntity, scene::Transform2D{});
+  ctx.registry.Insert(_state.quadEntity, _state.quadSprite);
 
-  auto circleRes = gameInstance->pMeshCache->AcquireMesh(resources::MeshShape::Circle);
+  // Circle sprite
+  auto circleRes = ctx.assetManager.LoadSprite("assets/textures/texture.jpg",
+                                               resources::MeshShape::Circle);
   if (!circleRes.has_value()) {
-    FLOG_ERROR("failed to acquire circle mesh");
+    FLOG_ERROR("failed to load circle sprite");
     return FeFalse;
   }
-  _state.circleMesh = circleRes.value();
+  _state.circleSprite = circleRes.value();
+  _state.circleEntity = ctx.registry.Create();
+  ctx.registry.Insert(_state.circleEntity, scene::Transform2D{0.0f, 1.2f});
+  ctx.registry.Insert(_state.circleEntity, _state.circleSprite);
 
-  auto capsuleRes = gameInstance->pMeshCache->AcquireMesh(resources::MeshShape::Capsule2D);
+  // Capsule sprite
+  auto capsuleRes = ctx.assetManager.LoadSprite("assets/textures/rugtexture.jpg",
+                                                resources::MeshShape::Capsule2D);
   if (!capsuleRes.has_value()) {
-    FLOG_ERROR("failed to acquire capsule mesh");
+    FLOG_ERROR("failed to load capsule sprite");
     return FeFalse;
   }
-  _state.capsuleMesh = capsuleRes.value();
+  _state.capsuleSprite = capsuleRes.value();
+  _state.capsuleEntity = ctx.registry.Create();
+  ctx.registry.Insert(_state.capsuleEntity, scene::Transform2D{-1.2f, 0.0f});
+  ctx.registry.Insert(_state.capsuleEntity, _state.capsuleSprite);
 
-  auto texRes = gameInstance->pTextureCache->AcquireTexture("assets/textures/texture.jpg");
-  if (!texRes.has_value()) {
-    FLOG_ERROR("failed to load texture");
-    return FeFalse;
-  }
-
-  _state.texHandle = texRes.value();
-
-  auto matRes = gameInstance->pMaterialCache->AcquireMaterial("quad_material", _state.texHandle);
-  if (!matRes.has_value()) {
-    FLOG_ERROR("failed to acquire material");
-    return FeFalse;
-  }
-
-  _state.matHandle = matRes.value();
-  _state.pMaterial = gameInstance->pMaterialCache->Get(_state.matHandle);
-
-  auto tex2Res = gameInstance->pTextureCache->AcquireTexture("assets/textures/rugtexture.jpg");
-  if (!tex2Res.has_value()) {
-    FLOG_ERROR("failed to load rug texture");
-    return FeFalse;
-  }
-
-  _state.tex2Handle = tex2Res.value();
-
-  auto mat2Res = gameInstance->pMaterialCache->AcquireMaterial("rug_material", _state.tex2Handle);
-  if (!mat2Res.has_value()) {
-    FLOG_ERROR("failed to acquire rug material");
-    return FeFalse;
-  }
-
-  _state.mat2Handle = mat2Res.value();
-  _state.pMaterial2 = gameInstance->pMaterialCache->Get(_state.mat2Handle);
   return FeTrue;
 }
 
 bool GameTest::GameUpdate(flatearth::Game *gameInstance, float32 deltaTime) {
-  using namespace input;
-  if (!gameInstance->pInputManager)
-    return FeFalse;
+  if (!gameInstance->pCtx) return FeFalse;
+  EngineContext &ctx = *gameInstance->pCtx;
+  input::InputManager &input = ctx.inputManager;
 
   const float32 dy = 3.0f * deltaTime;
   const float32 dx = 3.0f * deltaTime;
 
-  if (gameInstance->pInputManager->IsKeyDown(Keys::KEY_W)) {
-    _state.cameraPosition = _state.cameraPosition + math::Vec3D(0.0f, +dy, 0.0f);
-    _state.cameraViewDirty = FeTrue;
-  }
+  auto &camTransform = ctx.registry.Get<scene::Transform2D>(_state.cameraEntity);
+  if (input.IsKeyDown(input::Keys::KEY_W)) { camTransform.y += dy; camTransform.dirty = FeTrue; }
+  if (input.IsKeyDown(input::Keys::KEY_S)) { camTransform.y -= dy; camTransform.dirty = FeTrue; }
+  if (input.IsKeyDown(input::Keys::KEY_A)) { camTransform.x += dx; camTransform.dirty = FeTrue; }
+  if (input.IsKeyDown(input::Keys::KEY_D)) { camTransform.x -= dx; camTransform.dirty = FeTrue; }
 
-  if (gameInstance->pInputManager->IsKeyDown(Keys::KEY_S)) {
-    _state.cameraPosition = _state.cameraPosition + math::Vec3D(0.0f, -dy, 0.0f);
-    _state.cameraViewDirty = FeTrue;
-  }
+  _state.angle  += deltaTime * 1.5f;
+  _state.angle2 -= deltaTime * 2.0f;
+  _state.angle3 += deltaTime * 1.0f;
 
-  if (gameInstance->pInputManager->IsKeyDown(Keys::KEY_A)) {
-    _state.cameraPosition = _state.cameraPosition + math::Vec3D(+dx, 0.0f, 0.0f);
-    _state.cameraViewDirty = FeTrue;
-  }
-
-  if (gameInstance->pInputManager->IsKeyDown(Keys::KEY_D)) {
-    _state.cameraPosition = _state.cameraPosition + math::Vec3D(-dx, 0.0f, 0.0f);
-    _state.cameraViewDirty = FeTrue;
-  }
-
-  return FeTrue;
-}
-
-bool GameTest::GameRender(flatearth::Game *, renderer::RenderPacket &packet) {
-  RecalculateCameraView(_state);
-  packet.view = _state.view;
-
-  _state.angle += packet.deltaTime * 1.5f;
-  math::Mat4D model = math::Mat4D::RotationZ(_state.angle);
-  packet.objects.Push({_state.quadMesh, model, {}, {1.0f, 1.0f}, renderer::RenderLayer::Entities, _state.pMaterial});
-
-  _state.angle2 -= packet.deltaTime * 2.0f;
-  math::Mat4D model2 =
-      math::Mat4D::Translation(0.0f, 1.2f, 0.0f) * math::Mat4D::RotationZ(_state.angle2);
-  packet.objects.Push({_state.circleMesh, model2, {}, {1.0f, 1.0f}, renderer::RenderLayer::Entities, _state.pMaterial});
-
-  _state.angle3 += packet.deltaTime * 1.0f;
-  math::Mat4D model3 =
-      math::Mat4D::Translation(-1.2f, 0.0f, 0.0f) * math::Mat4D::RotationZ(_state.angle3);
-  packet.objects.Push({_state.capsuleMesh, model3, {}, {1.0f, 1.0f}, renderer::RenderLayer::Entities, _state.pMaterial2});
+  ctx.registry.Get<scene::Transform2D>(_state.quadEntity).rotation    = _state.angle;
+  ctx.registry.Get<scene::Transform2D>(_state.circleEntity).rotation  = _state.angle2;
+  ctx.registry.Get<scene::Transform2D>(_state.capsuleEntity).rotation = _state.angle3;
 
   return FeTrue;
 }
 
 void GameTest::GameUnload(flatearth::Game *gameInstance) {
-  if (gameInstance->pMeshCache) {
-    gameInstance->pMeshCache->Release(_state.quadMesh);
-    gameInstance->pMeshCache->Release(_state.circleMesh);
-    gameInstance->pMeshCache->Release(_state.capsuleMesh);
-  }
-  if (gameInstance->pMaterialCache) {
-    gameInstance->pMaterialCache->Release(_state.matHandle);
-    gameInstance->pMaterialCache->Release(_state.mat2Handle);
-  }
-  if (gameInstance->pTextureCache) {
-    gameInstance->pTextureCache->Release(_state.texHandle);
-    gameInstance->pTextureCache->Release(_state.tex2Handle);
-  }
+  if (!gameInstance->pCtx) return;
+  EngineContext &ctx = *gameInstance->pCtx;
+  ctx.assetManager.ReleaseSprite(_state.quadSprite);
+  ctx.assetManager.ReleaseSprite(_state.circleSprite);
+  ctx.assetManager.ReleaseSprite(_state.capsuleSprite);
 }
 
 bool GameTest::GameOnResize(flatearth::Game *, uint32, uint32) {

--- a/testbed/src/Game.cc
+++ b/testbed/src/Game.cc
@@ -4,6 +4,7 @@
 #include <Core/Input.hpp>
 #include <Core/Logger.hpp>
 #include <Defines.hpp>
+#include <Scene/Components/Camera2D.hpp>
 #include <Scene/Components/Transform2D.hpp>
 
 namespace flatearth::testbed {
@@ -25,7 +26,7 @@ bool GameTest::GameLoad(flatearth::Game *gameInstance) {
   // Camera entity
   _state.cameraEntity = ctx.registry.Create();
   ctx.registry.Insert(_state.cameraEntity, scene::Transform2D{});
-  ctx.registry.Insert(_state.cameraEntity, scene::Camera2D{});
+  ctx.registry.Insert(_state.cameraEntity, scene::Camera2D{.zoom = 0.5f});
 
   // Quad sprite
   auto quadRes = ctx.assetManager.LoadSprite("assets/textures/texture.jpg",
@@ -73,12 +74,16 @@ bool GameTest::GameUpdate(flatearth::Game *gameInstance, float32 deltaTime) {
 
   const float32 dy = 3.0f * deltaTime;
   const float32 dx = 3.0f * deltaTime;
+  const float32 zoomFactor = 1.0f + 1.5f * deltaTime;
 
   auto &camTransform = ctx.registry.Get<scene::Transform2D>(_state.cameraEntity);
+  auto &camComp = ctx.registry.Get<scene::Camera2D>(_state.cameraEntity);
   if (input.IsKeyDown(input::Keys::KEY_W)) { camTransform.y += dy; camTransform.dirty = FeTrue; }
   if (input.IsKeyDown(input::Keys::KEY_S)) { camTransform.y -= dy; camTransform.dirty = FeTrue; }
   if (input.IsKeyDown(input::Keys::KEY_A)) { camTransform.x += dx; camTransform.dirty = FeTrue; }
   if (input.IsKeyDown(input::Keys::KEY_D)) { camTransform.x -= dx; camTransform.dirty = FeTrue; }
+  if (input.IsKeyDown(input::Keys::KEY_Z)) { camComp.zoom *= zoomFactor; }
+  if (input.IsKeyDown(input::Keys::KEY_X)) { camComp.zoom /= zoomFactor; }
 
   _state.angle  += deltaTime * 1.5f;
   _state.angle2 -= deltaTime * 2.0f;

--- a/testbed/src/Game.hpp
+++ b/testbed/src/Game.hpp
@@ -2,31 +2,22 @@
 #define _FLATEARTH_TESTSUITE_GAME_HPP
 
 #include <Defines.hpp>
+#include <ECS/ECSTypes.hpp>
 #include <GameTypes.hpp>
-#include <Math/Matrix4D.hpp>
-#include <Renderer/RendererTypes.hpp>
-#include <Resources/MeshCache.hpp>
-#include <Resources/ResourceTypes.hpp>
+#include <Scene/Components/Camera2D.hpp>
+#include <Scene/Components/Sprite.hpp>
+#include <Scene/Components/Transform2D.hpp>
 
 namespace flatearth::testbed {
 
 struct GameState {
-  float32 deltaTime;
-  math::Mat4D view;
-  math::Vec3D cameraPosition, cameraEuler;
-  bool cameraViewDirty{false};
-
-  resources::TextureHandle texHandle{0};
-  resources::MaterialHandle matHandle{0};
-  resources::Material *pMaterial{nullptr};
-
-  resources::TextureHandle tex2Handle{0};
-  resources::MaterialHandle mat2Handle{0};
-  resources::Material *pMaterial2{nullptr};
-
-  resources::MeshHandle quadMesh{0};
-  resources::MeshHandle circleMesh{0};
-  resources::MeshHandle capsuleMesh{0};
+  ecs::EntityId cameraEntity{UINT32_MAX};
+  ecs::EntityId quadEntity{UINT32_MAX};
+  ecs::EntityId circleEntity{UINT32_MAX};
+  ecs::EntityId capsuleEntity{UINT32_MAX};
+  scene::Sprite quadSprite{};
+  scene::Sprite circleSprite{};
+  scene::Sprite capsuleSprite{};
   float32 angle{0.0f};
   float32 angle2{0.0f};
   float32 angle3{0.0f};
@@ -38,7 +29,6 @@ public:
   static bool GameLoad(flatearth::Game *gameInstance);
   static void GameUnload(flatearth::Game *gameInstance);
   static bool GameUpdate(flatearth::Game *gameInstance, float32 deltaTime);
-  static bool GameRender(flatearth::Game *gameInstance, renderer::RenderPacket &packet);
   static bool GameOnResize(flatearth::Game *gameInstance, uint32 width, uint32 height);
 
 private:

--- a/testbed/src/Game.hpp
+++ b/testbed/src/Game.hpp
@@ -4,7 +4,6 @@
 #include <Defines.hpp>
 #include <ECS/ECSTypes.hpp>
 #include <GameTypes.hpp>
-#include <Scene/Components/Camera2D.hpp>
 #include <Scene/Components/Sprite.hpp>
 #include <Scene/Components/Transform2D.hpp>
 
@@ -12,15 +11,16 @@ namespace flatearth::testbed {
 
 struct GameState {
   ecs::EntityId cameraEntity{UINT32_MAX};
-  ecs::EntityId quadEntity{UINT32_MAX};
-  ecs::EntityId circleEntity{UINT32_MAX};
-  ecs::EntityId capsuleEntity{UINT32_MAX};
-  scene::Sprite quadSprite{};
-  scene::Sprite circleSprite{};
-  scene::Sprite capsuleSprite{};
-  float32 angle{0.0f};
-  float32 angle2{0.0f};
-  float32 angle3{0.0f};
+  ecs::EntityId playerEntity{UINT32_MAX};
+  ecs::EntityId aiEntity{UINT32_MAX};
+  ecs::EntityId ballEntity{UINT32_MAX};
+
+  scene::Sprite paddleSprite{};
+  scene::Sprite ballSprite{};
+
+  float32 ballVx{1.5f};
+  float32 ballVy{0.8f};
+  bool    serveRight{true};
 };
 
 class GameTest {
@@ -32,6 +32,7 @@ public:
   static bool GameOnResize(flatearth::Game *gameInstance, uint32 width, uint32 height);
 
 private:
+  static void ResetBall(flatearth::Game *gameInstance);
   static GameState _state;
 };
 


### PR DESCRIPTION
This pull request introduces a new `AssetManager` class and refactors the core application architecture to centralize asset and system management. It also adds support for a new `Vec2D` field type in the ECS reflection/serialization system. The changes modernize resource handling, simplify engine context passing, improve event handling, and extend serialization capabilities.

**Asset and Resource Management:**

* Introduced a new `AssetManager` class (`AssetManager.hpp`, `AssetManager.cc`) to centralize texture and sprite loading, releasing, and management, replacing direct cache usage in the engine. [[1]](diffhunk://#diff-27b43d82ec968fdb2d570a7d5dad647608cc8607f5350dba384d67e90551f901R1-R86) [[2]](diffhunk://#diff-0cddb0839b7ee8c370392189b9ade76461a2754f19c7a31d69d8a320543fda51R1-R46)
* Refactored `Engine` to use `AssetManager` and removed direct references to `TextureCache`, `MaterialCache`, and `MeshCache`. The engine now initializes and shuts down resources through the new manager. [[1]](diffhunk://#diff-06014678d18a220dac3c5e4ccb0d7395acf7ff5ef6f1e2e4f4618bc91a8fc07dR11-R31) [[2]](diffhunk://#diff-c7648116c08db440e30ae61aea98961e452a204ad89f06b218b9714e083c7369R4-R14) [[3]](diffhunk://#diff-c7648116c08db440e30ae61aea98961e452a204ad89f06b218b9714e083c7369L34-R40)

**Engine Architecture and Context:**

* Added an `EngineContext` struct to encapsulate references to core managers (`AssetManager`, `MemoryManager`, `InputManager`, `Registry`) and passed it to game instances, simplifying dependency management. [[1]](diffhunk://#diff-047cf618f4cc08c83e4a87096c3fd4fef12edcca3822cf1c22820312c3031b43R1-R27) [[2]](diffhunk://#diff-06014678d18a220dac3c5e4ccb0d7395acf7ff5ef6f1e2e4f4618bc91a8fc07dR42-R43)
* Replaced `FrontendRenderer` with `GameRenderer` in the engine and event listener, updating initialization, shutdown, and event handling logic accordingly. [[1]](diffhunk://#diff-06014678d18a220dac3c5e4ccb0d7395acf7ff5ef6f1e2e4f4618bc91a8fc07dL76-L89) [[2]](diffhunk://#diff-5085c7569eab842a37bfd9090257c808d6e34073d81650ff953df16090b3e877L4-R13) [[3]](diffhunk://#diff-4e68bfd9088c4cabe5532923219c0f8f99ccdb28623e84c9b656127d5efe317bL6-R17) [[4]](diffhunk://#diff-4e68bfd9088c4cabe5532923219c0f8f99ccdb28623e84c9b656127d5efe317bL44-R46)

**ECS System Management:**

* Integrated a `SystemScheduler` and `Registry` into the engine, registering and building core systems (`TransformSystem`, `SpriteSystem`) during initialization, and updating them each frame instead of relying on the game instance's `Render()` function. [[1]](diffhunk://#diff-06014678d18a220dac3c5e4ccb0d7395acf7ff5ef6f1e2e4f4618bc91a8fc07dR98-R115) [[2]](diffhunk://#diff-06014678d18a220dac3c5e4ccb0d7395acf7ff5ef6f1e2e4f4618bc91a8fc07dL137-R159) [[3]](diffhunk://#diff-06014678d18a220dac3c5e4ccb0d7395acf7ff5ef6f1e2e4f4618bc91a8fc07dL187-L191)

**Event Handling Improvements:**

* Improved event handling in `EngineListener`, including correct shutdown on `ApplicationQuit` and support for a new `FileLoaded` event code. [[1]](diffhunk://#diff-5085c7569eab842a37bfd9090257c808d6e34073d81650ff953df16090b3e877L131-L135) [[2]](diffhunk://#diff-1e66c54c5a2024f3bdd9639f314e486589f60c47391ff8e74626fd0bedf46cd8R22)

**ECS Reflection/Serialization Enhancements:**

* Added support for a `Vec2D` field type in the ECS reflection system, including type registration, size calculation, name, and JSON (de)serialization. [[1]](diffhunk://#diff-7116d2c7e5f77541872558f1560e28d408054f123a5ea64d9ee3d08643bdf4b9L20-R27) [[2]](diffhunk://#diff-7116d2c7e5f77541872558f1560e28d408054f123a5ea64d9ee3d08643bdf4b9R50-R58) [[3]](diffhunk://#diff-7116d2c7e5f77541872558f1560e28d408054f123a5ea64d9ee3d08643bdf4b9R81-R82) [[4]](diffhunk://#diff-41db1e77a5949dd0f458fbbf78af25bbabf0ed97fbb891d52afcf1f77bf69edcR15) [[5]](diffhunk://#diff-41db1e77a5949dd0f458fbbf78af25bbabf0ed97fbb891d52afcf1f77bf69edcR27-R32) [[6]](diffhunk://#diff-41db1e77a5949dd0f458fbbf78af25bbabf0ed97fbb891d52afcf1f77bf69edcR42) [[7]](diffhunk://#diff-41db1e77a5949dd0f458fbbf78af25bbabf0ed97fbb891d52afcf1f77bf69edcR54-R61)