### PR TITLE
Transform Hierarchy Implementation

### DIFF
--- a/engine/src/Containers/HashSet.hpp
+++ b/engine/src/Containers/HashSet.hpp
@@ -25,20 +25,23 @@ public:
   explicit HashSet(memory::MemoryManager &memManager, uint64 bucketCount = 64)
       : _memoryManager(memManager), _bucketCount(bucketCount) {
     assert(bucketCount > 0);
-    _ppBuckets = FeCast<FePtr<Node<T>> *>(_memoryManager.RawAlloc(
+    _ppBuckets = FeCast<FePtr<Node<T>>>(_memoryManager.RawAlloc(
         sizeof(FePtr<Node<T>>) * _bucketCount, alignof(FePtr<Node<T>>), memory::Tag::HashSet));
 
-    // initialize to null
     for (uint64 i = 0; i < _bucketCount; i++) {
-      _ppBuckets[i] = nullptr;
+      new (&_ppBuckets[i]) FePtr<Node<T>>();
     }
   }
 
   ~HashSet() {
-    if (_ppBuckets != nullptr) {
-      _memoryManager.RawFree(
-          _ppBuckets, sizeof(FePtr<Node<T>>) * _bucketCount, memory::Tag::HashSet);
+    if (_ppBuckets == nullptr) return;
+
+    for (uint64 i = 0; i < _bucketCount; i++) {
+      _ppBuckets[i].~FePtr<Node<T>>();
     }
+
+    _memoryManager.RawFree(
+        _ppBuckets, sizeof(FePtr<Node<T>>) * _bucketCount, memory::Tag::HashSet);
   }
 
   inline FeExpect<bool, Error> Insert(const T &value) {
@@ -102,6 +105,15 @@ public:
     }
 
     return FeFalse;
+  }
+
+  template <typename Fn>
+  void ForEach(Fn &&fn) {
+    for (uint64 i = 0; i < _bucketCount; i++) {
+      for (Node<T> *node = _ppBuckets[i].get(); node != nullptr; node = node->pNext.get()) {
+        fn(node->data);
+      }
+    }
   }
 
   inline uint64 Size() const { return _size; }

--- a/engine/src/Core/Application.cc
+++ b/engine/src/Core/Application.cc
@@ -153,7 +153,6 @@ FeExpect<void, Error> Engine::Start() {
     }
 
     _scheduler.Update(_registry, deltaTime);
-
     auto drawRes = _renderer.Draw(deltaTime);
     if (!drawRes.has_value()) {
       FLOG_ERROR("game renderer failed to draw frame: {}", drawRes.error().message);

--- a/engine/src/ECS/Reflect/FieldType.hpp
+++ b/engine/src/ECS/Reflect/FieldType.hpp
@@ -23,7 +23,7 @@ enum class FieldType : uint8 {
 
 constexpr uint8 FieldSize(FieldType t) {
   switch (t) {
-    case FieldType::Null:
+    default:
       return 0;
     case FieldType::Bool:
       return 1;

--- a/engine/src/ECS/Scheduler/SystemScheduler.cc
+++ b/engine/src/ECS/Scheduler/SystemScheduler.cc
@@ -105,6 +105,7 @@ FeExpect<void, Error> SystemScheduler::Build() {
     string out = std::format("the number of processed nodes '{}' is not equal _nodesMap.Size '{}'",
                              processed,
                              _nodesMap.Size());
+    Prune();
     return FeErr{Error(out, ErrorType::LogicalError)};
   }
 

--- a/engine/src/Renderer/GameRenderer.cc
+++ b/engine/src/Renderer/GameRenderer.cc
@@ -28,8 +28,8 @@ FeExpect<bool, Error> GameRenderer::Draw(float32 deltaTime) {
   for (auto [entity, transform, cam] : cameraView) {
     // grabs first active camera
     view = math::Mat4D::Scale(cam.zoom, cam.zoom, 1.0f) *
-           math::Mat4D::Translation(-transform.x, -transform.y, 0.0f) *
-           math::Mat4D::RotationZ(-transform.rotation);
+           math::Mat4D::Translation(-transform.worldX, -transform.worldY, 0.0f) *
+           math::Mat4D::RotationZ(-transform.worldRotation);
     break;
   }
 
@@ -45,9 +45,9 @@ FeExpect<bool, Error> GameRenderer::Draw(float32 deltaTime) {
       continue;
     }
 
-    math::Mat4D model = math::Mat4D::Translation(transform.x, transform.y, 0.0f) *
-                        math::Mat4D::RotationZ(transform.rotation) *
-                        math::Mat4D::Scale(transform.scaleX, transform.scaleY, 1.0f);
+    math::Mat4D model = math::Mat4D::Translation(transform.worldX, transform.worldY, 0.0f) *
+                        math::Mat4D::RotationZ(transform.worldRotation) *
+                        math::Mat4D::Scale(transform.worldScaleX, transform.worldScaleY, 1.0f);
     RenderObject object{
         .geometryId = pMesh->id,
         .model = model,

--- a/engine/src/Scene/Components/Transform2D.hpp
+++ b/engine/src/Scene/Components/Transform2D.hpp
@@ -16,6 +16,12 @@ struct Transform2D {
   float32 scaleY{1.0f};
 
   // Runtime, not reflected
+  float32 worldX{0.0f};
+  float32 worldY{0.0f};
+  float32 worldRotation{0.0f};
+  float32 worldScaleX{1.0f};
+  float32 worldScaleY{1.0f};
+
   ecs::EntityId parent{cNullEntity};
   bool dirty{FeTrue};
 };

--- a/engine/src/Scene/Systems/TransformSystem.cc
+++ b/engine/src/Scene/Systems/TransformSystem.cc
@@ -1,35 +1,110 @@
 #include "Scene/Systems/TransformSystem.hpp"
 
+#include "Containers/HashSet.hpp"
+#include "Core/Logger.hpp"
+#include "ECS/ECSTypes.hpp"
+#include "Math/FeMath.hpp"
 #include "Scene/Components/Children.hpp"
 #include "Scene/Components/Transform2D.hpp"
 
 namespace flatearth::systems {
 
 using scene::Children;
+using scene::cNullEntity;
 using scene::Transform2D;
 
 TransformSystem::TransformSystem(memory::MemoryManager &memManager) : _memoryManager(memManager) {
 }
 
-void TransformSystem::Update(ecs::Registry &registry, float32 deltaTime) {
+void TransformSystem::Update(ecs::Registry &registry, float32) {
   ecs::View<Transform2D> view = registry.ViewOf<Transform2D>();
 
+  containers::HashSet<ecs::EntityId> matusalemSet(_memoryManager);
   for (auto [entity, transform] : view) {
     if (!transform.dirty) {
       continue;
     }
 
-    if (!registry.Has<Children>(entity)) {
+    if (transform.parent != cNullEntity) {
+      ecs::EntityId antecessorId = PropagateTransformBackwards(registry, transform.parent);
+      if (matusalemSet.Has(antecessorId)) {
+        continue;
+      }
+
+      auto res = matusalemSet.Insert(antecessorId);
+      if (!res.has_value()) {
+        FLOG_ERROR("failed to insert entity '{}' into antecessor's (matusalem) map", antecessorId);
+      }
       continue;
     }
 
-    Children &children = registry.Get<Children>(entity);
-    for (uint8 i = 0; i < children.count; i++) {
-      ecs::EntityId child = children.ids[i];
-      if (registry.Has<Transform2D>(child)) {
-        registry.Get<Transform2D>(child).dirty = FeTrue;
-      }
+    auto _ = matusalemSet.Insert(entity);
+  }
+
+  matusalemSet.ForEach([&](const ecs::EntityId &id) {
+    if (!registry.Has<Transform2D>(id)) {
+      return;
     }
+
+    auto &transform = registry.Get<Transform2D>(id);
+    PropagateTransformForward(registry, id, transform, nullptr);
+  });
+}
+
+ecs::EntityId TransformSystem::PropagateTransformBackwards(ecs::Registry &registry,
+                                                           ecs::EntityId parent) {
+  if (!registry.Has<Transform2D>(parent)) {
+    FLOG_ERROR("parent of transform has no Transform2D component");
+    return cNullEntity;
+  }
+
+  Transform2D &parentT = registry.Get<Transform2D>(parent);
+  parentT.dirty = FeTrue;
+  if (parentT.parent != cNullEntity) {
+    return PropagateTransformBackwards(registry, parentT.parent);
+  }
+
+  return parent;
+}
+
+void TransformSystem::PropagateTransformForward(ecs::Registry &registry,
+                                                ecs::EntityId entity,
+                                                Transform2D &transform,
+                                                const Transform2D *pParentTransform) {
+  if (pParentTransform != nullptr) {
+    float32 cos = math::Cos(pParentTransform->worldRotation);
+    float32 sin = math::Sin(pParentTransform->worldRotation);
+
+    transform.worldX = pParentTransform->worldX +
+                       pParentTransform->worldScaleX * (cos * transform.x - sin * transform.y);
+    transform.worldY = pParentTransform->worldY +
+                       pParentTransform->worldScaleY * (sin * transform.x + cos * transform.y);
+    transform.worldRotation = pParentTransform->worldRotation + transform.rotation;
+    transform.worldScaleX = pParentTransform->worldScaleX * transform.scaleX;
+    transform.worldScaleY = pParentTransform->worldScaleY * transform.scaleY;
+  } else {
+    transform.worldX = transform.x;
+    transform.worldY = transform.y;
+    transform.worldRotation = transform.rotation;
+    transform.worldScaleX = transform.scaleX;
+    transform.worldScaleY = transform.scaleY;
+  }
+
+  transform.dirty = FeFalse;
+
+  if (!registry.Has<Children>(entity)) {
+    return;
+  }
+
+  Children &children = registry.Get<Children>(entity);
+  for (uint8 i = 0; i < children.count; i++) {
+    ecs::EntityId childId = children.ids[i];
+    if (!registry.Has<Transform2D>(childId)) {
+      continue;
+    }
+
+    Transform2D &child = registry.Get<Transform2D>(childId);
+    PropagateTransformForward(registry, childId, child, &transform);
   }
 }
 

--- a/engine/src/Scene/Systems/TransformSystem.hpp
+++ b/engine/src/Scene/Systems/TransformSystem.hpp
@@ -3,6 +3,7 @@
 
 #include "Core/FeMemory.hpp"
 #include "ECS/SystemInterface.hpp"
+#include "Scene/Components/Transform2D.hpp"
 
 namespace flatearth::systems {
 
@@ -10,6 +11,15 @@ class TransformSystem : public ecs::ISystem {
 public:
   explicit TransformSystem(memory::MemoryManager &memManager);
   void Update(ecs::Registry &registry, float32 deltaTime) override;
+
+private:
+  ecs::EntityId PropagateTransformBackwards(ecs::Registry &registry,
+                                   ecs::EntityId parent);
+
+  void PropagateTransformForward(ecs::Registry &registry,
+                          ecs::EntityId entity,
+                          scene::Transform2D &transform,
+                          const scene::Transform2D *parent);
 
 private:
   memory::MemoryManager &_memoryManager;


### PR DESCRIPTION
This pull request significantly refactors the transform propagation logic in the `TransformSystem`, introducing world-space transform computation for hierarchical entities and improving the handling of transform updates. The changes also include updates to the `HashSet` container, adjustments to the renderer to use world-space transforms, and minor fixes elsewhere.

**Transform propagation and world-space computation:**

* Refactored `TransformSystem` to introduce explicit forward and backward propagation methods, ensuring parent transforms are updated before children and computing world-space position, rotation, and scale for each entity. Added new fields to `Transform2D` to store these world-space values. [[1]](diffhunk://#diff-8036634c32e1c0c8ee26774d0f098f09e2b49909f658a098ae1d2d35052af94bR3-R107) [[2]](diffhunk://#diff-f51a0e7522e4fec3cea4f4bb6f34350798142a5e4ee11a3cf3d019c477bfbca3R19-R24) [[3]](diffhunk://#diff-597846f37ad9241a82cee7729b003982dac0966862d9d788a720dff3b3eee4a3R15-R23)

* Updated the renderer (`GameRenderer::Draw`) to use the new world-space transform fields, ensuring objects and cameras are rendered correctly according to the scene hierarchy. [[1]](diffhunk://#diff-8cc3e4c645af4b8d2fd5442fcade3f13518dd039a92a13f8ef8aa5eb62ed3000L31-R32) [[2]](diffhunk://#diff-8cc3e4c645af4b8d2fd5442fcade3f13518dd039a92a13f8ef8aa5eb62ed3000L48-R50)

**Data structure and utility improvements:**

* Improved `HashSet` initialization and destruction to properly construct and destruct bucket elements, and added a `ForEach` method for iteration. [[1]](diffhunk://#diff-acd25624137771ff26f00c3b2b965ecba206ddf7254bfd1cbe95642499a64fbeL28-L42) [[2]](diffhunk://#diff-acd25624137771ff26f00c3b2b965ecba206ddf7254bfd1cbe95642499a64fbeR110-R118)

**Bug fixes and minor changes:**

* Changed the `FieldSize` function to return 0 by default for unrecognized field types, improving safety.
* Added a call to `Prune()` in `SystemScheduler::Build` on logical error, ensuring cleanup after errors.