### PR TITLE
Feat/physics box2d

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -22,6 +22,25 @@ include(GNUInstallDirs)
 set(LIBRARY_BASE_PATH "${PROJECT_SOURCE_DIR}/src")
 
 ############################################################################
+#   DEPENDENCIES
+
+include(FetchContent)
+
+FetchContent_Declare(
+    box2d
+    GIT_REPOSITORY https://github.com/erincatto/box2d.git
+    GIT_TAG        v3.0.0
+    GIT_SHALLOW    TRUE
+)
+
+set(BOX2D_BUILD_UNIT_TESTS OFF CACHE BOOL "" FORCE)
+set(BOX2D_BUILD_TESTBED    OFF CACHE BOOL "" FORCE)
+set(BOX2D_BUILD_DOCS       OFF CACHE BOOL "" FORCE)
+
+FetchContent_MakeAvailable(box2d)
+set_target_properties(box2d PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+############################################################################
 #   PROJECT DEFINITIONS
 
 file(GLOB_RECURSE SOURCE_FILES "${LIBRARY_BASE_PATH}/*.cc")
@@ -62,13 +81,16 @@ if(UNIX AND NOT MSVC)
             X11-xcb
             xcb-keysyms
             Vulkan::Vulkan
+            box2d
     )
 elseif(WIN32)
     if(MSVC)
         target_compile_options(${BINARY_NAME} PRIVATE /W4 /permissive-)
-        target_link_libraries(${BINARY_NAME} PRIVATE Vulkan::Vulkan)
+        target_link_libraries(${BINARY_NAME} PRIVATE Vulkan::Vulkan box2d)
     endif()
 endif()
+
+target_include_directories(${BINARY_NAME} PRIVATE $<TARGET_PROPERTY:box2d,INTERFACE_INCLUDE_DIRECTORIES>)
 
 # Define FEXPORT so your code can detect and handle export logic internally
 target_compile_definitions(${BINARY_NAME} PRIVATE FEXPORT)

--- a/engine/src/Core/Application.cc
+++ b/engine/src/Core/Application.cc
@@ -8,6 +8,7 @@
 #include "Core/Logger.hpp"
 #include "Defines.hpp"
 #include "Error.hpp"
+#include "Physics/PhysicsSystem.hpp"
 #include "Scene/Systems/SpriteSystem.hpp"
 #include "Scene/Systems/TransformSystem.hpp"
 
@@ -17,8 +18,8 @@ Engine::Engine(Game *pGame)
     : _appState(pGame), _eventManager(_memoryManager), _inputManager(_eventManager),
       _renderer(&_appState, _memoryManager, _registry, _filesystem), _filesystem(_memoryManager),
       _assetManager(_memoryManager, _filesystem), _scheduler(_memoryManager),
-      _registry(_memoryManager), _sceneManager(_memoryManager, _registry),
-      _ctx(_memoryManager, _assetManager, _inputManager, _registry, _sceneManager) {
+      _registry(_memoryManager), _sceneManager(_memoryManager, _registry), _world(_memoryManager),
+      _ctx(_memoryManager, _assetManager, _inputManager, _registry, _sceneManager, _world) {
   _engineListener = _memoryManager.Allocate<event::IEventListener, EngineListener>(
       memory::Tag::Application, _eventManager, _renderer, _appState);
 }
@@ -29,6 +30,7 @@ Engine::~Engine() {
   }
   _renderer.Shutdown();
   _assetManager.Shutdown();
+  _world.Shutdown();
   FLOG_INFO("engine shutdown gracefully");
 }
 
@@ -95,6 +97,7 @@ FeExpect<void, Error> Engine::Initialize() {
     }
   }
 
+  _world.Initialize();
   auto registerRes = _scheduler.Register<systems::TransformSystem>(_memoryManager);
   if (!registerRes.has_value()) {
     FLOG_ERROR("could not register TransformSystem into scheduler");
@@ -105,6 +108,12 @@ FeExpect<void, Error> Engine::Initialize() {
   if (!spriteRes.has_value()) {
     FLOG_ERROR("could not register SpriteSystem into scheduler");
     return FeErr{spriteRes.error()};
+  }
+
+  auto physicsRes = _scheduler.Register<physics::PhysicsSystem>(_world);
+  if (!physicsRes.has_value()) {
+    FLOG_ERROR("could not register PhysicsSystem into scheduler");
+    return FeErr{physicsRes.error()};
   }
 
   auto buildRes = _scheduler.Build();

--- a/engine/src/Core/Application.hpp
+++ b/engine/src/Core/Application.hpp
@@ -9,6 +9,7 @@
 #include "ECS/Registry.hpp"
 #include "ECS/Scheduler/SystemScheduler.hpp"
 #include "GameTypes.hpp"
+#include "Physics/FlatearthWorld.hpp"
 #include "Platform/Filesystem.hpp"
 #include "Platform/Platform.hpp"
 #include "Renderer/GameRenderer.hpp"
@@ -38,6 +39,7 @@ private:
   ecs::Registry _registry;
   renderer::GameRenderer _renderer;
   scene::SceneManager _sceneManager;
+  physics::FlatearthWorld _world;
   FePtr<event::IEventListener> _engineListener;
   EngineContext _ctx;
 };

--- a/engine/src/Core/EngineContext.hpp
+++ b/engine/src/Core/EngineContext.hpp
@@ -5,6 +5,7 @@
 #include "Core/FeMemory.hpp"
 #include "Core/Input.hpp"
 #include "ECS/Registry.hpp"
+#include "Physics/FlatearthWorld.hpp"
 #include "Scene/SceneManager.hpp"
 
 namespace flatearth {
@@ -15,14 +16,16 @@ struct EngineContext {
   input::InputManager &inputManager;
   ecs::Registry &registry;
   scene::SceneManager &sceneManager;
+  physics::FlatearthWorld &world;
 
   explicit EngineContext(memory::MemoryManager &memManager,
                          assets::AssetManager &assetManager,
                          input::InputManager &inputManager,
                          ecs::Registry &registry,
-                         scene::SceneManager &sceneManager)
+                         scene::SceneManager &sceneManager,
+                         physics::FlatearthWorld &world)
       : assetManager(assetManager), memoryManager(memManager), inputManager(inputManager),
-        registry(registry), sceneManager(sceneManager) {}
+        registry(registry), sceneManager(sceneManager), world(world) {}
 };
 
 } // namespace flatearth

--- a/engine/src/Physics/BoxCollider.hpp
+++ b/engine/src/Physics/BoxCollider.hpp
@@ -1,0 +1,21 @@
+#ifndef _FLATEARTH_ENGINE_PHYSICS_BOX_COLLIDER_HPP
+#define _FLATEARTH_ENGINE_PHYSICS_BOX_COLLIDER_HPP
+
+#include "Defines.hpp"
+#include "Math/Vector2D.hpp"
+#include "Physics/PhysicsHandle.hpp"
+
+namespace flatearth::physics {
+
+struct BoxCollider {
+  float32 halfWidth{0.5f};
+  float32 halfHeight{0.5f};
+  math::Vec2D offset{0.0f, 0.0f};
+  bool isSensor{FeFalse};
+
+  FeShapeHandle shapeId{};
+};
+
+}
+
+#endif // _FLATEARTH_ENGINE_PHYSICS_BOX_COLLIDER_HPP

--- a/engine/src/Physics/CircleCollider.hpp
+++ b/engine/src/Physics/CircleCollider.hpp
@@ -1,0 +1,20 @@
+#ifndef _FLATEARTH_ENGINE_PHYSICS_CIRCLE_COLLIDER_HPP
+#define _FLATEARTH_ENGINE_PHYSICS_CIRCLE_COLLIDER_HPP
+
+#include "Defines.hpp"
+#include "Math/Vector2D.hpp"
+#include "Physics/PhysicsHandle.hpp"
+
+namespace flatearth::physics {
+
+struct CircleCollider {
+  float32 radius{0.5f};
+  math::Vec2D offset{0.0f, 0.0f};
+  bool isSensor{FeFalse};
+
+  FeShapeHandle shapeId{};
+};
+
+}
+
+#endif // _FLATEARTH_ENGINE_PHYSICS_CIRCLE_COLLIDER_HPP

--- a/engine/src/Physics/FlatearthWorld.cc
+++ b/engine/src/Physics/FlatearthWorld.cc
@@ -1,0 +1,48 @@
+#include "FlatearthWorld.hpp"
+#include "box2d/box2d.h"
+
+#include <cstring>
+
+namespace flatearth::physics {
+
+static b2WorldId ToB2(FeWorldHandle h) {
+  b2WorldId id;
+  std::memcpy(&id, &h, sizeof(id));
+  return id;
+}
+
+static FeWorldHandle FromB2(b2WorldId id) {
+  FeWorldHandle h;
+  std::memcpy(&h, &id, sizeof(h));
+  return h;
+}
+
+FlatearthWorld::FlatearthWorld(memory::MemoryManager &memManager) {}
+
+FeWorldHandle FlatearthWorld::WorldId() const { return _worldHandle; }
+
+void FlatearthWorld::Initialize(float32 gravityX, float32 gravityY) {
+  if (_initialized) {
+    return;
+  }
+
+  b2WorldDef def = b2DefaultWorldDef();
+  def.gravity = {gravityX, gravityY};
+  _worldHandle = FromB2(b2CreateWorld(&def));
+  _initialized = FeTrue;
+}
+
+void FlatearthWorld::Step(float32 deltaTime, int32 subSteps) {
+  b2World_Step(ToB2(_worldHandle), deltaTime, subSteps);
+}
+
+void FlatearthWorld::Shutdown() {
+  b2WorldId id = ToB2(_worldHandle);
+  if (B2_IS_NON_NULL(id)) {
+    b2DestroyWorld(id);
+    _worldHandle = {};
+    _initialized = FeFalse;
+  }
+}
+
+} // namespace flatearth::physics

--- a/engine/src/Physics/FlatearthWorld.hpp
+++ b/engine/src/Physics/FlatearthWorld.hpp
@@ -1,0 +1,29 @@
+#ifndef _FLATEARTH_ENGINE_PHYSICS_FLATEARTH_WORLD_HPP
+#define _FLATEARTH_ENGINE_PHYSICS_FLATEARTH_WORLD_HPP
+
+#include "Defines.hpp"
+#include "PhysicsTypes.hpp"
+#include "Physics/PhysicsHandle.hpp"
+#include "Core/FeMemory.hpp"
+
+namespace flatearth::physics {
+
+class FlatearthWorld {
+public:
+  explicit FlatearthWorld(memory::MemoryManager &memManager);
+
+  void Initialize(float32 gravityX = cFlatearthGravityForce.x(),
+                  float32 gravityY = cFlatearthGravityForce.y());
+  void Step(float32 deltaTime, int32 subSteps = 4);
+  void Shutdown();
+
+  FeWorldHandle WorldId() const;
+
+private:
+  FeWorldHandle _worldHandle{};
+  bool _initialized{FeFalse};
+};
+
+} // namespace flatearth::physics
+
+#endif // _FLATEARTH_ENGINE_PHYSICS_FLATEARTH_WORLD_HPP

--- a/engine/src/Physics/PhysicsHandle.hpp
+++ b/engine/src/Physics/PhysicsHandle.hpp
@@ -1,0 +1,35 @@
+#ifndef _FLATEARTH_ENGINE_PHYSICS_PHYSICS_HANDLE_HPP
+#define _FLATEARTH_ENGINE_PHYSICS_PHYSICS_HANDLE_HPP
+
+#include "Defines.hpp"
+
+namespace flatearth::physics {
+
+// Opaque handles matching box2d's b2WorldId / b2BodyId / b2ShapeId layout.
+// Engine internals (PhysicsSystem.cc, FlatearthWorld.cc) cast via memcpy.
+// Game code uses these directly — no box2d headers needed.
+
+struct FeWorldHandle {
+  uint16 index1{0};
+  uint16 revision{0};
+};
+
+struct FeBodyHandle {
+  int32  index1{0};
+  uint16 world0{0};
+  uint16 revision{0};
+};
+
+struct FeShapeHandle {
+  int32  index1{0};
+  uint16 world0{0};
+  uint16 revision{0};
+};
+
+inline bool IsNull(FeWorldHandle h) { return h.index1 == 0; }
+inline bool IsNull(FeBodyHandle h)  { return h.index1 == 0; }
+inline bool IsNull(FeShapeHandle h) { return h.index1 == 0; }
+
+} // namespace flatearth::physics
+
+#endif // _FLATEARTH_ENGINE_PHYSICS_PHYSICS_HANDLE_HPP

--- a/engine/src/Physics/PhysicsSystem.cc
+++ b/engine/src/Physics/PhysicsSystem.cc
@@ -1,0 +1,118 @@
+#include "PhysicsSystem.hpp"
+
+#include "Physics/BoxCollider.hpp"
+#include "Physics/CircleCollider.hpp"
+#include "Physics/FlatearthWorld.hpp"
+#include "Physics/RigidBody.hpp"
+#include "Scene/Components/Transform2D.hpp"
+#include "box2d/box2d.h"
+
+#include <cstring>
+
+namespace flatearth::physics {
+
+static b2WorldId ToB2World(FeWorldHandle h) {
+  b2WorldId id;
+  std::memcpy(&id, &h, sizeof(id));
+  return id;
+}
+
+static b2BodyId ToB2Body(FeBodyHandle h) {
+  b2BodyId id;
+  std::memcpy(&id, &h, sizeof(id));
+  return id;
+}
+
+static FeBodyHandle FromB2Body(b2BodyId id) {
+  FeBodyHandle h;
+  std::memcpy(&h, &id, sizeof(h));
+  return h;
+}
+
+static b2ShapeId ToB2Shape(FeShapeHandle h) {
+  b2ShapeId id;
+  std::memcpy(&id, &h, sizeof(id));
+  return id;
+}
+
+static FeShapeHandle FromB2Shape(b2ShapeId id) {
+  FeShapeHandle h;
+  std::memcpy(&h, &id, sizeof(h));
+  return h;
+}
+
+PhysicsSystem::PhysicsSystem(FlatearthWorld &world) : _world(world) {
+}
+
+void PhysicsSystem::Update(ecs::Registry &registry, float32 deltaTime) {
+  CreateBodies(registry);
+  _world.Step(deltaTime);
+  SyncTransforms(registry);
+}
+
+void PhysicsSystem::CreateBodies(ecs::Registry &registry) {
+  auto view = registry.ViewOf<scene::Transform2D, RigidBody>();
+  b2WorldId worldId = ToB2World(_world.WorldId());
+
+  for (auto [entity, transform, body] : view) {
+    if (!IsNull(body.bodyId)) {
+      continue;
+    }
+
+    b2BodyDef def = b2DefaultBodyDef();
+    def.position = {transform.worldX, transform.worldY};
+    def.rotation = b2MakeRot(transform.worldRotation);
+    def.type = body.type == BodyType::Static    ? b2_staticBody
+               : body.type == BodyType::Dynamic ? b2_dynamicBody
+                                                : b2_kinematicBody;
+    def.linearDamping  = body.linearDamping;
+    def.angularDamping = body.angularDamping;
+    def.fixedRotation  = body.fixedRotation;
+
+    b2BodyId b2Body = b2CreateBody(worldId, &def);
+    body.bodyId = FromB2Body(b2Body);
+
+    b2ShapeDef shapeDef = b2DefaultShapeDef();
+    shapeDef.density     = body.density;
+    shapeDef.friction    = body.friction;
+    shapeDef.restitution = body.restitution;
+
+    if (registry.Has<BoxCollider>(entity)) {
+      auto &collider = registry.Get<BoxCollider>(entity);
+      shapeDef.isSensor = collider.isSensor;
+      float32 angle = 0.0f;
+      b2Polygon box = b2MakeOffsetBox(collider.halfWidth,
+                                      collider.halfHeight,
+                                      {collider.offset.x(), collider.offset.y()},
+                                      angle);
+      collider.shapeId = FromB2Shape(b2CreatePolygonShape(b2Body, &shapeDef, &box));
+    }
+
+    if (registry.Has<CircleCollider>(entity)) {
+      auto &collider = registry.Get<CircleCollider>(entity);
+      shapeDef.isSensor = collider.isSensor;
+      b2Circle circle = {{collider.offset.x(), collider.offset.y()}, collider.radius};
+      collider.shapeId = FromB2Shape(b2CreateCircleShape(b2Body, &shapeDef, &circle));
+    }
+  }
+}
+
+void PhysicsSystem::SyncTransforms(ecs::Registry &registry) {
+  auto view = registry.ViewOf<scene::Transform2D, RigidBody>();
+
+  for (auto [entity, transform, body] : view) {
+    if (IsNull(body.bodyId) || body.type == BodyType::Static) {
+      continue;
+    }
+
+    b2BodyId b2Body = ToB2Body(body.bodyId);
+    b2Vec2 pos = b2Body_GetPosition(b2Body);
+    b2Rot  rot = b2Body_GetRotation(b2Body);
+    transform.x        = pos.x;
+    transform.y        = pos.y;
+    transform.rotation = b2Rot_GetAngle(rot);
+    transform.dirty    = FeTrue;
+  }
+}
+
+} // namespace flatearth::physics

--- a/engine/src/Physics/PhysicsSystem.cc
+++ b/engine/src/Physics/PhysicsSystem.cc
@@ -41,11 +41,12 @@ static FeShapeHandle FromB2Shape(b2ShapeId id) {
   return h;
 }
 
-PhysicsSystem::PhysicsSystem(FlatearthWorld &world) : _world(world) {
-}
+PhysicsSystem::PhysicsSystem(FlatearthWorld &world) : _world(world) {}
 
 void PhysicsSystem::Update(ecs::Registry &registry, float32 deltaTime) {
   CreateBodies(registry);
+  ProcessTeleports(registry);
+  ApplyKinematicVelocities(registry);
   _world.Step(deltaTime);
   SyncTransforms(registry);
 }
@@ -60,11 +61,11 @@ void PhysicsSystem::CreateBodies(ecs::Registry &registry) {
     }
 
     b2BodyDef def = b2DefaultBodyDef();
-    def.position = {transform.worldX, transform.worldY};
-    def.rotation = b2MakeRot(transform.worldRotation);
-    def.type = body.type == BodyType::Static    ? b2_staticBody
-               : body.type == BodyType::Dynamic ? b2_dynamicBody
-                                                : b2_kinematicBody;
+    def.position      = {transform.worldX, transform.worldY};
+    def.rotation      = b2MakeRot(transform.worldRotation);
+    def.type          = body.type == BodyType::Static    ? b2_staticBody
+                        : body.type == BodyType::Dynamic ? b2_dynamicBody
+                                                         : b2_kinematicBody;
     def.linearDamping  = body.linearDamping;
     def.angularDamping = body.angularDamping;
     def.fixedRotation  = body.fixedRotation;
@@ -72,28 +73,59 @@ void PhysicsSystem::CreateBodies(ecs::Registry &registry) {
     b2BodyId b2Body = b2CreateBody(worldId, &def);
     body.bodyId = FromB2Body(b2Body);
 
-    b2ShapeDef shapeDef = b2DefaultShapeDef();
-    shapeDef.density     = body.density;
-    shapeDef.friction    = body.friction;
-    shapeDef.restitution = body.restitution;
+    if (!body.velocity.Equals(math::Vec2D{0.0f, 0.0f})) {
+      b2Body_SetLinearVelocity(b2Body, {body.velocity.x(), body.velocity.y()});
+    }
+
+    b2ShapeDef shapeDef   = b2DefaultShapeDef();
+    shapeDef.density      = body.density;
+    shapeDef.friction     = body.friction;
+    shapeDef.restitution  = body.restitution;
 
     if (registry.Has<BoxCollider>(entity)) {
-      auto &collider = registry.Get<BoxCollider>(entity);
+      auto &collider    = registry.Get<BoxCollider>(entity);
       shapeDef.isSensor = collider.isSensor;
-      float32 angle = 0.0f;
-      b2Polygon box = b2MakeOffsetBox(collider.halfWidth,
-                                      collider.halfHeight,
-                                      {collider.offset.x(), collider.offset.y()},
-                                      angle);
+      float32 angle     = 0.0f;
+      b2Polygon box     = b2MakeOffsetBox(collider.halfWidth,
+                                          collider.halfHeight,
+                                          {collider.offset.x(), collider.offset.y()},
+                                          angle);
       collider.shapeId = FromB2Shape(b2CreatePolygonShape(b2Body, &shapeDef, &box));
     }
 
     if (registry.Has<CircleCollider>(entity)) {
-      auto &collider = registry.Get<CircleCollider>(entity);
+      auto &collider    = registry.Get<CircleCollider>(entity);
       shapeDef.isSensor = collider.isSensor;
-      b2Circle circle = {{collider.offset.x(), collider.offset.y()}, collider.radius};
-      collider.shapeId = FromB2Shape(b2CreateCircleShape(b2Body, &shapeDef, &circle));
+      b2Circle circle   = {{collider.offset.x(), collider.offset.y()}, collider.radius};
+      collider.shapeId  = FromB2Shape(b2CreateCircleShape(b2Body, &shapeDef, &circle));
     }
+  }
+}
+
+void PhysicsSystem::ProcessTeleports(ecs::Registry &registry) {
+  auto view = registry.ViewOf<scene::Transform2D, RigidBody>();
+
+  for (auto [entity, transform, body] : view) {
+    if (!body.teleport || IsNull(body.bodyId)) {
+      continue;
+    }
+
+    b2BodyId b2Body = ToB2Body(body.bodyId);
+    b2Body_SetTransform(b2Body, {transform.x, transform.y}, b2MakeRot(transform.rotation));
+    b2Body_SetLinearVelocity(b2Body, {body.velocity.x(), body.velocity.y()});
+    b2Body_SetAngularVelocity(b2Body, 0.0f);
+    body.teleport = FeFalse;
+  }
+}
+
+void PhysicsSystem::ApplyKinematicVelocities(ecs::Registry &registry) {
+  auto view = registry.ViewOf<scene::Transform2D, RigidBody>();
+
+  for (auto [entity, transform, body] : view) {
+    if (body.type != BodyType::Kinematic || IsNull(body.bodyId)) {
+      continue;
+    }
+    b2Body_SetLinearVelocity(ToB2Body(body.bodyId), {body.velocity.x(), body.velocity.y()});
   }
 }
 
@@ -105,9 +137,9 @@ void PhysicsSystem::SyncTransforms(ecs::Registry &registry) {
       continue;
     }
 
-    b2BodyId b2Body = ToB2Body(body.bodyId);
-    b2Vec2 pos = b2Body_GetPosition(b2Body);
-    b2Rot  rot = b2Body_GetRotation(b2Body);
+    b2BodyId b2Body    = ToB2Body(body.bodyId);
+    b2Vec2 pos         = b2Body_GetPosition(b2Body);
+    b2Rot  rot         = b2Body_GetRotation(b2Body);
     transform.x        = pos.x;
     transform.y        = pos.y;
     transform.rotation = b2Rot_GetAngle(rot);

--- a/engine/src/Physics/PhysicsSystem.hpp
+++ b/engine/src/Physics/PhysicsSystem.hpp
@@ -13,6 +13,8 @@ public:
 
 private:
   void CreateBodies(ecs::Registry &registry);
+  void ProcessTeleports(ecs::Registry &registry);
+  void ApplyKinematicVelocities(ecs::Registry &registry);
   void SyncTransforms(ecs::Registry &registry);
 
 private:

--- a/engine/src/Physics/PhysicsSystem.hpp
+++ b/engine/src/Physics/PhysicsSystem.hpp
@@ -1,0 +1,24 @@
+#ifndef _FLATEARTH_ENGINE_PHYSICS_PHYSICS_SYSTEM_HPP
+#define _FLATEARTH_ENGINE_PHYSICS_PHYSICS_SYSTEM_HPP
+
+#include "ECS/SystemInterface.hpp"
+#include "Physics/FlatearthWorld.hpp"
+
+namespace flatearth::physics {
+
+class PhysicsSystem : public ecs::ISystem {
+public:
+  explicit PhysicsSystem(FlatearthWorld &world);
+  void Update(ecs::Registry &registry, float32 deltaTime) override;
+
+private:
+  void CreateBodies(ecs::Registry &registry);
+  void SyncTransforms(ecs::Registry &registry);
+
+private:
+  FlatearthWorld &_world;
+};
+
+}
+
+#endif // _FLATEARTH_ENGINE_PHYSICS_PHYSICS_SYSTEM_HPP

--- a/engine/src/Physics/PhysicsTypes.hpp
+++ b/engine/src/Physics/PhysicsTypes.hpp
@@ -1,0 +1,12 @@
+#ifndef _FLATEARTH_ENGINE_PHYSICS_PHYSICS_TYPES_HPP
+#define _FLATEARTH_ENGINE_PHYSICS_PHYSICS_TYPES_HPP
+
+#include "Math/Vector2D.hpp"
+
+namespace flatearth::physics {
+
+constexpr math::Vec2D cFlatearthGravityForce{0.0f, -9.8f};
+
+}
+
+#endif // _FLATEARTH_ENGINE_PHYSICS_PHYSICS_TYPES_HPP

--- a/engine/src/Physics/RigidBody.hpp
+++ b/engine/src/Physics/RigidBody.hpp
@@ -1,0 +1,30 @@
+#ifndef _FLATEARTH_ENGINE_PHYSICS_RIGID_BODY_HPP
+#define _FLATEARTH_ENGINE_PHYSICS_RIGID_BODY_HPP
+
+#include "Defines.hpp"
+#include "Physics/PhysicsHandle.hpp"
+
+namespace flatearth::physics {
+
+enum class BodyType : uint8 {
+  Static,
+  Dynamic,
+  Kinematic,
+};
+
+struct RigidBody {
+  BodyType type{BodyType::Dynamic};
+  float32  density{1.0f};
+  float32  friction{0.3f};
+  float32  restitution{0.0f};
+  float32  linearDamping{0.0f};
+  float32  angularDamping{0.0f};
+  bool     fixedRotation{FeFalse};
+
+  // Runtime only — managed by PhysicsSystem
+  FeBodyHandle bodyId{};
+};
+
+} // namespace flatearth::physics
+
+#endif // _FLATEARTH_ENGINE_PHYSICS_RIGID_BODY_HPP

--- a/engine/src/Physics/RigidBody.hpp
+++ b/engine/src/Physics/RigidBody.hpp
@@ -2,6 +2,7 @@
 #define _FLATEARTH_ENGINE_PHYSICS_RIGID_BODY_HPP
 
 #include "Defines.hpp"
+#include "Math/Vector2D.hpp"
 #include "Physics/PhysicsHandle.hpp"
 
 namespace flatearth::physics {
@@ -13,13 +14,18 @@ enum class BodyType : uint8 {
 };
 
 struct RigidBody {
-  BodyType type{BodyType::Dynamic};
-  float32  density{1.0f};
-  float32  friction{0.3f};
-  float32  restitution{0.0f};
-  float32  linearDamping{0.0f};
-  float32  angularDamping{0.0f};
-  bool     fixedRotation{FeFalse};
+  BodyType    type{BodyType::Dynamic};
+  float32     density{1.0f};
+  float32     friction{0.3f};
+  float32     restitution{0.0f};
+  float32     linearDamping{0.0f};
+  float32     angularDamping{0.0f};
+  bool        fixedRotation{FeFalse};
+
+  // Kinematic: applied every frame. Dynamic: applied once at creation as initial velocity.
+  math::Vec2D velocity{0.0f, 0.0f};
+  // Set to true + update Transform2D to teleport the body next frame.
+  bool        teleport{FeFalse};
 
   // Runtime only — managed by PhysicsSystem
   FeBodyHandle bodyId{};

--- a/testbed/src/Game.cc
+++ b/testbed/src/Game.cc
@@ -5,57 +5,54 @@
 #include <Core/Logger.hpp>
 #include <Defines.hpp>
 #include <Math/FeMath.hpp>
+#include <Physics/BoxCollider.hpp>
+#include <Physics/CircleCollider.hpp>
+#include <Physics/RigidBody.hpp>
 #include <Scene/Components/Camera2D.hpp>
 #include <Scene/Components/Transform2D.hpp>
 #include <Scene/Scene.hpp>
 
 namespace flatearth::testbed {
 
-// ── field dimensions (orthographic: x in [-aspect,aspect], y in [-1,1]) ─────
+// World dimensions (orthographic): x in [-aspect, aspect], y in [-1, 1]
 static constexpr float32 cAspect = 1280.0f / 720.0f;
-static constexpr float32 cPaddleX = 1.5f;
-static constexpr float32 cPaddleScaleX = 0.08f;
-static constexpr float32 cPaddleScaleY = 0.35f;
-static constexpr float32 cPaddleHalfW = cPaddleScaleX * 0.5f;
-static constexpr float32 cPaddleHalfH = cPaddleScaleY * 0.5f;
-static constexpr float32 cBallScale = 0.08f;
-static constexpr float32 cBallHalf = cBallScale * 0.5f;
-static constexpr float32 cWallY = 1.0f;
-static constexpr float32 cPlayerSpeed = 2.5f;
-static constexpr float32 cAISpeed = 2.2f;
-static constexpr float32 cBallInitVx = 1.5f;
-static constexpr float32 cBallInitVy = 0.8f;
-static constexpr float32 cSpeedupRate = 1.05f;
+
+// Platform
+static constexpr float32 cPlatformY = -0.75f;
+static constexpr float32 cPlatformHalfW = 0.25f;
+static constexpr float32 cPlatformHalfH = 0.03f;
+static constexpr float32 cPlatformSpeed = 2.5f;
+static constexpr float32 cPlatformScaleX = cPlatformHalfW * 2.0f;
+static constexpr float32 cPlatformScaleY = cPlatformHalfH * 2.0f;
+
+// Ball
+static constexpr float32 cBallRadius = 0.05f;
+static constexpr float32 cBallScale = cBallRadius * 2.0f;
+static constexpr float32 cBallStartX = 0.0f;
+static constexpr float32 cBallStartY = 0.3f;
+static constexpr float32 cBallInitVx = 0.5f;
+static constexpr float32 cBallInitVy = -1.5f;
+
+// Walls
+static constexpr float32 cWallThick = 0.05f;
+
+// Ball falls below this y → reset
+static constexpr float32 cDeathY = -1.1f;
 
 GameState GameTest::_state = GameState{};
 
-// ── helpers ──────────────────────────────────────────────────────────────────
-
-static inline float32 Clamp(float32 v, float32 lo, float32 hi) {
-  return v < lo ? lo : (v > hi ? hi : v);
-}
-
-static inline bool AABBOverlap(float32 ax,
-                               float32 ay,
-                               float32 ahw,
-                               float32 ahh,
-                               float32 bx,
-                               float32 by,
-                               float32 bhw,
-                               float32 bhh) {
-  return math::Abs(ax - bx) < ahw + bhw && math::Abs(ay - by) < ahh + bhh;
-}
+// ── helpers ───────────────────────────────────────────────────────────────────
 
 void GameTest::ResetBall(flatearth::Game *gameInstance) {
   EngineContext &ctx = *gameInstance->pCtx;
-  auto &t = ctx.registry.Get<scene::Transform2D>(_state.ballEntity);
-  t.x = 0.0f;
-  t.y = 0.0f;
-  t.dirty = FeTrue;
+  auto &ballT = ctx.registry.Get<scene::Transform2D>(_state.ballEntity);
+  auto &ballB = ctx.registry.Get<physics::RigidBody>(_state.ballEntity);
 
-  _state.serveRight = !_state.serveRight;
-  _state.ballVx = _state.serveRight ? cBallInitVx : -cBallInitVx;
-  _state.ballVy = cBallInitVy;
+  ballT.x = cBallStartX;
+  ballT.y = cBallStartY;
+  ballT.dirty = FeTrue;
+  ballB.velocity = math::Vec2D{cBallInitVx, cBallInitVy};
+  ballB.teleport = FeTrue;
 }
 
 // ── lifecycle ─────────────────────────────────────────────────────────────────
@@ -65,53 +62,36 @@ bool GameTest::GameInitialize(flatearth::Game *gameInstance) {
   gameInstance->windowStartHeight = 720;
   gameInstance->windowStartPosX = 100;
   gameInstance->windowStartPosY = 100;
-  gameInstance->gameName = "Pong";
+  gameInstance->gameName = "KeepItUp";
   return FeTrue;
 }
 
 bool GameTest::GameLoad(flatearth::Game *gameInstance) {
   EngineContext &ctx = *gameInstance->pCtx;
 
-  auto sceneRes = ctx.sceneManager.Load("pong");
+  auto sceneRes = ctx.sceneManager.Load("keepitup");
   if (!sceneRes.has_value()) {
-    FLOG_ERROR("failed to create pong scene");
+    FLOG_ERROR("failed to create keepitup scene");
     return FeFalse;
   }
   scene::Scene *pScene = sceneRes.value();
 
-  // Camera — static, centered
+  // ── camera ───────────────────────────────────────────────────────────────
   _state.cameraEntity = ctx.registry.Create();
   ctx.registry.Insert(_state.cameraEntity, scene::Transform2D{});
   ctx.registry.Insert(_state.cameraEntity, scene::Camera2D{});
   pScene->roots.push_back(_state.cameraEntity);
   pScene->allEntities.push_back(_state.cameraEntity);
 
-  // Paddle sprite (shared by both paddles)
-  auto paddleRes =
+  // ── sprites ───────────────────────────────────────────────────────────────
+  auto platRes =
       ctx.assetManager.LoadSprite("assets/textures/texture.jpg", resources::MeshShape::Quad);
-  if (!paddleRes.has_value()) {
-    FLOG_ERROR("failed to load paddle sprite");
+  if (!platRes.has_value()) {
+    FLOG_ERROR("failed to load platform sprite");
     return FeFalse;
   }
-  _state.paddleSprite = paddleRes.value();
+  _state.platformSprite = platRes.value();
 
-  // Player paddle — left side
-  _state.playerEntity = ctx.registry.Create();
-  ctx.registry.Insert(_state.playerEntity,
-                      scene::Transform2D{-cPaddleX, 0.0f, 0.0f, cPaddleScaleX, cPaddleScaleY});
-  ctx.registry.Insert(_state.playerEntity, _state.paddleSprite);
-  pScene->roots.push_back(_state.playerEntity);
-  pScene->allEntities.push_back(_state.playerEntity);
-
-  // AI paddle — right side (same sprite, different entity)
-  _state.aiEntity = ctx.registry.Create();
-  ctx.registry.Insert(_state.aiEntity,
-                      scene::Transform2D{cPaddleX, 0.0f, 0.0f, cPaddleScaleX, cPaddleScaleY});
-  ctx.registry.Insert(_state.aiEntity, _state.paddleSprite);
-  pScene->roots.push_back(_state.aiEntity);
-  pScene->allEntities.push_back(_state.aiEntity);
-
-  // Ball sprite
   auto ballRes =
       ctx.assetManager.LoadSprite("assets/textures/rugtexture.jpg", resources::MeshShape::Circle);
   if (!ballRes.has_value()) {
@@ -119,12 +99,51 @@ bool GameTest::GameLoad(flatearth::Game *gameInstance) {
     return FeFalse;
   }
   _state.ballSprite = ballRes.value();
+
+  // ── platform (kinematic) ──────────────────────────────────────────────────
+  _state.platformEntity = ctx.registry.Create();
+  ctx.registry.Insert(_state.platformEntity,
+                      scene::Transform2D{0.0f, cPlatformY, 0.0f, cPlatformScaleX, cPlatformScaleY});
+  ctx.registry.Insert(
+      _state.platformEntity,
+      physics::RigidBody{.type = physics::BodyType::Kinematic, .fixedRotation = FeTrue});
+  ctx.registry.Insert(
+      _state.platformEntity,
+      physics::BoxCollider{.halfWidth = cPlatformHalfW, .halfHeight = cPlatformHalfH});
+  ctx.registry.Insert(_state.platformEntity, _state.platformSprite);
+  pScene->roots.push_back(_state.platformEntity);
+  pScene->allEntities.push_back(_state.platformEntity);
+
+  // ── ball (dynamic) ────────────────────────────────────────────────────────
   _state.ballEntity = ctx.registry.Create();
   ctx.registry.Insert(_state.ballEntity,
-                      scene::Transform2D{0.0f, 0.0f, 0.0f, cBallScale, cBallScale});
+                      scene::Transform2D{cBallStartX, cBallStartY, 0.0f, cBallScale, cBallScale});
+  ctx.registry.Insert(_state.ballEntity,
+                      physics::RigidBody{.type = physics::BodyType::Dynamic,
+                                         .friction = 0.1f,
+                                         .restitution = 0.7f,
+                                         .fixedRotation = FeTrue,
+                                         .velocity = math::Vec2D{cBallInitVx, cBallInitVy}});
+  ctx.registry.Insert(_state.ballEntity, physics::CircleCollider{.radius = cBallRadius});
   ctx.registry.Insert(_state.ballEntity, _state.ballSprite);
   pScene->roots.push_back(_state.ballEntity);
   pScene->allEntities.push_back(_state.ballEntity);
+
+  // ── static walls ─────────────────────────────────────────────────────────
+  auto MakeWall = [&](float32 x, float32 y, float32 hw, float32 hh) {
+    auto e = ctx.registry.Create();
+    ctx.registry.Insert(e, scene::Transform2D{x, y});
+    ctx.registry.Insert(e, physics::RigidBody{.type = physics::BodyType::Static});
+    ctx.registry.Insert(e, physics::BoxCollider{.halfWidth = hw, .halfHeight = hh});
+    pScene->allEntities.push_back(e);
+  };
+
+  // Left wall — inner edge at x = -cAspect
+  MakeWall(-(cAspect + cWallThick), 0.0f, cWallThick, 1.1f);
+  // Right wall — inner edge at x = +cAspect
+  MakeWall((cAspect + cWallThick), 0.0f, cWallThick, 1.1f);
+  // Top wall — inner edge at y = +1
+  MakeWall(0.0f, 1.0f + cWallThick, cAspect + cWallThick, cWallThick);
 
   return FeTrue;
 }
@@ -134,67 +153,33 @@ bool GameTest::GameLoad(flatearth::Game *gameInstance) {
 bool GameTest::GameUpdate(flatearth::Game *gameInstance, float32 deltaTime) {
   if (!gameInstance->pCtx)
     return FeFalse;
+
   EngineContext &ctx = *gameInstance->pCtx;
   input::InputManager &input = ctx.inputManager;
 
-  auto &player = ctx.registry.Get<scene::Transform2D>(_state.playerEntity);
-  auto &ai = ctx.registry.Get<scene::Transform2D>(_state.aiEntity);
-  auto &ball = ctx.registry.Get<scene::Transform2D>(_state.ballEntity);
+  auto &platT = ctx.registry.Get<scene::Transform2D>(_state.platformEntity);
+  auto &platB = ctx.registry.Get<physics::RigidBody>(_state.platformEntity);
+  auto &ballT = ctx.registry.Get<scene::Transform2D>(_state.ballEntity);
+  auto &ballB = ctx.registry.Get<physics::RigidBody>(_state.ballEntity);
 
-  // ── player input ──────────────────────────────────────────────────────────
-  if (input.IsKeyDown(input::Keys::KEY_W)) {
-    player.y =
-        Clamp(player.y + cPlayerSpeed * deltaTime, -(cWallY - cPaddleHalfH), cWallY - cPaddleHalfH);
-    player.dirty = FeTrue;
-  }
-  if (input.IsKeyDown(input::Keys::KEY_S)) {
-    player.y =
-        Clamp(player.y - cPlayerSpeed * deltaTime, -(cWallY - cPaddleHalfH), cWallY - cPaddleHalfH);
-    player.dirty = FeTrue;
-  }
+  // ── platform movement ─────────────────────────────────────────────────────
+  float32 vx = 0.0f;
+  if (input.IsKeyDown(input::Keys::KEY_LEFT) || input.IsKeyDown(input::Keys::KEY_A))
+    vx = -cPlatformSpeed;
+  if (input.IsKeyDown(input::Keys::KEY_RIGHT) || input.IsKeyDown(input::Keys::KEY_D))
+    vx = cPlatformSpeed;
 
-  // ── AI paddle tracks ball ─────────────────────────────────────────────────
-  float32 aiDiff = ball.y - ai.y;
-  float32 aiMove = Clamp(aiDiff, -cAISpeed * deltaTime, cAISpeed * deltaTime);
-  ai.y = Clamp(ai.y + aiMove, -(cWallY - cPaddleHalfH), cWallY - cPaddleHalfH);
-  ai.dirty = FeTrue;
+  // Clamp: stop at screen edges
+  if (platT.x - cPlatformHalfW <= -cAspect && vx < 0.0f)
+    vx = 0.0f;
+  if (platT.x + cPlatformHalfW >= cAspect && vx > 0.0f)
+    vx = 0.0f;
 
-  // ── move ball ─────────────────────────────────────────────────────────────
-  ball.x += _state.ballVx * deltaTime;
-  ball.y += _state.ballVy * deltaTime;
-  ball.dirty = FeTrue;
+  platB.velocity = math::Vec2D{vx, 0.0f};
 
-  // ── wall bounce (top / bottom) ────────────────────────────────────────────
-  if (ball.y + cBallHalf >= cWallY) {
-    ball.y = cWallY - cBallHalf;
-    _state.ballVy = -math::Abs(_state.ballVy);
-  } else if (ball.y - cBallHalf <= -cWallY) {
-    ball.y = -cWallY + cBallHalf;
-    _state.ballVy = math::Abs(_state.ballVy);
-  }
-
-  // ── paddle collision ──────────────────────────────────────────────────────
-  auto PaddleHit = [&](scene::Transform2D &paddle) {
-    if (!AABBOverlap(
-            ball.x, ball.y, cBallHalf, cBallHalf, paddle.x, paddle.y, cPaddleHalfW, cPaddleHalfH))
-      return;
-
-    float32 relHit = (ball.y - paddle.y) / cPaddleHalfH;
-    _state.ballVx = -_state.ballVx * cSpeedupRate;
-    _state.ballVy = Clamp(_state.ballVy + relHit * 1.5f, -3.0f, 3.0f);
-
-    // push ball out of paddle to prevent tunnelling
-    ball.x = paddle.x + ((_state.ballVx > 0) ? 1.0f : -1.0f) * (cPaddleHalfW + cBallHalf);
-  };
-
-  if (_state.ballVx < 0)
-    PaddleHit(player);
-  else
-    PaddleHit(ai);
-
-  // ── out of bounds → reset ─────────────────────────────────────────────────
-  if (ball.x > cAspect + cBallHalf || ball.x < -(cAspect + cBallHalf)) {
-    FLOG_INFO("point scored — resetting ball");
+  // ── reset ball if it falls off the bottom ─────────────────────────────────
+  if (ballT.y < cDeathY) {
+    FLOG_INFO("ball fell — resetting");
     ResetBall(gameInstance);
   }
 
@@ -205,9 +190,9 @@ void GameTest::GameUnload(flatearth::Game *gameInstance) {
   if (!gameInstance->pCtx)
     return;
   EngineContext &ctx = *gameInstance->pCtx;
-  ctx.assetManager.ReleaseSprite(_state.paddleSprite);
+  ctx.assetManager.ReleaseSprite(_state.platformSprite);
   ctx.assetManager.ReleaseSprite(_state.ballSprite);
-  ctx.sceneManager.Unload("pong");
+  ctx.sceneManager.Unload("keepitup");
 }
 
 bool GameTest::GameOnResize(flatearth::Game *, uint32, uint32) {

--- a/testbed/src/Game.hpp
+++ b/testbed/src/Game.hpp
@@ -11,16 +11,11 @@ namespace flatearth::testbed {
 
 struct GameState {
   ecs::EntityId cameraEntity{UINT32_MAX};
-  ecs::EntityId playerEntity{UINT32_MAX};
-  ecs::EntityId aiEntity{UINT32_MAX};
   ecs::EntityId ballEntity{UINT32_MAX};
+  ecs::EntityId platformEntity{UINT32_MAX};
 
-  scene::Sprite paddleSprite{};
+  scene::Sprite platformSprite{};
   scene::Sprite ballSprite{};
-
-  float32 ballVx{1.5f};
-  float32 ballVy{0.8f};
-  bool serveRight{true};
 };
 
 class GameTest {


### PR DESCRIPTION
This pull request introduces a new 2D physics integration using Box2D, adds core physics components and systems, and refactors the game testbed to use the new physics engine. The most important changes are grouped as follows:

**Physics Engine Integration:**

* Added Box2D as a dependency and integrated it into the CMake build system, ensuring it is linked and included for all platforms (`engine/CMakeLists.txt`). [[1]](diffhunk://#diff-1292c6f7f812b50bda3b43b5a80a670c4c9a86cae1037cc760a75e45a1ae1f1aR24-R42) [[2]](diffhunk://#diff-1292c6f7f812b50bda3b43b5a80a670c4c9a86cae1037cc760a75e45a1ae1f1aR84-R94)

**Physics System and Components:**

* Implemented the `FlatearthWorld` physics world wrapper, which manages Box2D world lifecycle and stepping (`FlatearthWorld.hpp`, `FlatearthWorld.cc`). [[1]](diffhunk://#diff-4a27f197b3a4c417fb7603dfcb3468dec9f708ff2068d3951e042e99e121bfe8R1-R29) [[2]](diffhunk://#diff-29f7cb8bca04804616016916f84a82bafc579d2c6913d8bcee047a48c3aefc0eR1-R48)
* Added core physics components: `RigidBody`, `BoxCollider`, `CircleCollider`, and opaque handle types for world, body, and shape IDs, allowing engine code to interact with physics objects without direct Box2D dependency (`RigidBody.hpp`, `BoxCollider.hpp`, `CircleCollider.hpp`, `PhysicsHandle.hpp`). [[1]](diffhunk://#diff-c0c61034affe4232379a5b575ada736e7b5547392fd62b06fb7ee4616acf22bdR1-R36) [[2]](diffhunk://#diff-c79d36d019cf2db21195ca697fff9d9d87537b274b225c3233d9c297437d0b38R1-R21) [[3]](diffhunk://#diff-efcac0810489bfbb30a07af24acfcf7477dd3dc9c81a79da12e16b7ffddeb518R1-R20) [[4]](diffhunk://#diff-a3ef9c4a33a73707ea13d3f690872856fc175daf9c541a345ee86a559a4c196dR1-R35)
* Defined default physics constants (e.g., gravity) in `PhysicsTypes.hpp`.

* Added the `PhysicsSystem`, which creates physics bodies/shapes, synchronizes transforms, and handles kinematic and teleport logic, registering it with the scheduler (`PhysicsSystem.hpp`, `PhysicsSystem.cc`, `Application.cc`, `Application.hpp`, `EngineContext.hpp`). [[1]](diffhunk://#diff-f8768fed38f0b292f158b21599f937a9d7d00bd525629397cb0a9383e48b5b19R1-R26) [[2]](diffhunk://#diff-f86836a9b610b0289d74916fcca504b39a8fa2ba60516e2a91385b68e3e84b01R1-R150) [[3]](diffhunk://#diff-06014678d18a220dac3c5e4ccb0d7395acf7ff5ef6f1e2e4f4618bc91a8fc07dR11) [[4]](diffhunk://#diff-06014678d18a220dac3c5e4ccb0d7395acf7ff5ef6f1e2e4f4618bc91a8fc07dL20-R22) [[5]](diffhunk://#diff-06014678d18a220dac3c5e4ccb0d7395acf7ff5ef6f1e2e4f4618bc91a8fc07dR33) [[6]](diffhunk://#diff-06014678d18a220dac3c5e4ccb0d7395acf7ff5ef6f1e2e4f4618bc91a8fc07dR100) [[7]](diffhunk://#diff-06014678d18a220dac3c5e4ccb0d7395acf7ff5ef6f1e2e4f4618bc91a8fc07dR113-R118) [[8]](diffhunk://#diff-c7648116c08db440e30ae61aea98961e452a204ad89f06b218b9714e083c7369R12) [[9]](diffhunk://#diff-c7648116c08db440e30ae61aea98961e452a204ad89f06b218b9714e083c7369R42) [[10]](diffhunk://#diff-047cf618f4cc08c83e4a87096c3fd4fef12edcca3822cf1c22820312c3031b43R8) [[11]](diffhunk://#diff-047cf618f4cc08c83e4a87096c3fd4fef12edcca3822cf1c22820312c3031b43R19-R28)

**Testbed Refactor:**

* Refactored the testbed game to use the new physics system and components, replacing manual collision and movement logic with physics-driven behavior (`testbed/src/Game.cc`).

These changes lay the foundation for robust, component-based 2D physics in the engine, enabling future gameplay and simulation features to leverage Box2D through a clean, engine-owned API.