### PR TITLE
sprite flip mechanism

### DIFF
--- a/engine/src/Scene/Components/Sprite.cc
+++ b/engine/src/Scene/Components/Sprite.cc
@@ -1,5 +1,6 @@
 #include "Sprite.hpp"
 
+#include "ECS/Reflect/FieldType.hpp"
 #include "ECS/Reflect/Reflect.hpp"
 
 namespace flatearth::scene {
@@ -9,6 +10,8 @@ FIELD(layer, ecs::reflect::FieldType::Uint32)
 FIELD(meshShape, ecs::reflect::FieldType::Uint16)
 FIELD(uvOffset, ecs::reflect::FieldType::Vec2D)
 FIELD(uvScale, ecs::reflect::FieldType::Vec2D)
+FIELD(flipX, ecs::reflect::FieldType::Bool)
+FIELD(flipY, ecs::reflect::FieldType::Bool)
 END_REFLECT
 
 } // namespace flatearth::scene

--- a/engine/src/Scene/Components/Sprite.hpp
+++ b/engine/src/Scene/Components/Sprite.hpp
@@ -13,6 +13,7 @@ struct Sprite {
   resources::MeshShape meshShape{resources::MeshShape::Quad};
   math::Vec2D uvOffset{0.0f, 0.0f};
   math::Vec2D uvScale{1.0f, 1.0f};
+  bool flipX{FeFalse}, flipY{FeFalse};
 
   // Runtime only, not reflected
   bool dirty{FeTrue};

--- a/engine/src/Scene/Systems/SpriteSystem.cc
+++ b/engine/src/Scene/Systems/SpriteSystem.cc
@@ -7,14 +7,18 @@ namespace flatearth::systems {
 using namespace scene;
 
 void SpriteSystem::Update(ecs::Registry &registry, float32 deltaTime) {
-  ecs::View<Sprite, SpriteAnimator> view = registry.ViewOf<Sprite, SpriteAnimator>();
-
-  for (auto &&[entity, sprite, animator] : view) {
-    if (!animator.playing || animator.frameCount == 0) {
+  ecs::View<Sprite, SpriteAnimator> animView = registry.ViewOf<Sprite, SpriteAnimator>();
+  for (auto &&[entity, sprite, animator] : animView) {
+    if (!animator.playing || animator.frameCount == 0)
       continue;
-    }
-
     UpdateAnimator(animator, sprite, deltaTime);
+  }
+
+  ecs::View<Sprite> spriteView = registry.ViewOf<Sprite>();
+  for (auto &&[entity, sprite] : spriteView) {
+    if (!sprite.dirty)
+      continue;
+    UpdateSprite(sprite);
   }
 }
 
@@ -35,6 +39,15 @@ void SpriteSystem::UpdateAnimator(SpriteAnimator &animator, Sprite &sprite, floa
     sprite.uvOffset = frame.uvOffset;
     sprite.uvScale = frame.uvScale;
     sprite.dirty = FeTrue;
+  }
+}
+
+void SpriteSystem::UpdateSprite(Sprite &sprite) {
+  if (sprite.flipX) {
+    sprite.uvScale = sprite.uvScale * math::Vec2D{-1, 1};
+  }
+  if (sprite.flipY) {
+    sprite.uvScale = sprite.uvScale * math::Vec2D{1, -1};
   }
 }
 

--- a/engine/src/Scene/Systems/SpriteSystem.hpp
+++ b/engine/src/Scene/Systems/SpriteSystem.hpp
@@ -13,6 +13,7 @@ public:
 
 private:
   void UpdateAnimator(scene::SpriteAnimator &animator, scene::Sprite &sprite, float32 deltaTime);
+  void UpdateSprite(scene::Sprite &sprite);
 };
 
 } // namespace flatearth::systems

--- a/testbed/src/Game.cc
+++ b/testbed/src/Game.cc
@@ -140,6 +140,12 @@ bool GameTest::GameUpdate(flatearth::Game *gameInstance, float32 deltaTime) {
   }
   sprite.uvOffset = anim.frames[anim.currentFrame].uvOffset;
   sprite.uvScale  = anim.frames[anim.currentFrame].uvScale;
+
+  if (input.IsKeyDown(input::KEY_F) && !input.WasKeyDown(input::KEY_F))
+    sprite.flipX = !sprite.flipX;
+  if (input.IsKeyDown(input::KEY_G) && !input.WasKeyDown(input::KEY_G))
+    sprite.flipY = !sprite.flipY;
+
   sprite.dirty    = FeTrue;
 
   playerXform.x += dx * speed * deltaTime;


### PR DESCRIPTION
This pull request adds support for horizontal and vertical flipping of sprites via new `flipX` and `flipY` properties. These properties are reflected for serialization and can be toggled in the testbed using the `F` and `G` keys. The sprite system was updated to handle these new properties and apply the appropriate UV scaling.

**Sprite Flipping Feature:**

* Added `flipX` and `flipY` boolean fields to the `Sprite` component, including default values and reflection support for serialization and editing. [[1]](diffhunk://#diff-7e6d25aced2ce25254a9d14f124b1546807857758bd622b5d0ff0aef026c7f9dR16) [[2]](diffhunk://#diff-476aa4070c38595accfa636afa3044cd7d0d8f56fe99a4f0e1240f12021eafa7R13-R14) [[3]](diffhunk://#diff-476aa4070c38595accfa636afa3044cd7d0d8f56fe99a4f0e1240f12021eafa7R3)
* Implemented toggling of `flipX` and `flipY` in the testbed using the `F` and `G` keys, respectively.

**Sprite System Updates:**

* Refactored `SpriteSystem::Update` to process all sprites, updating only those marked as `dirty`, and to handle both animated and non-animated sprites.
* Added `UpdateSprite` method to apply UV scale inversion based on the `flipX` and `flipY` properties. [[1]](diffhunk://#diff-58b5facf4da106e0327cfbc8528c3cf2f01eaaa5e4ef09c2438bb24ad55faf79R45-R53) [[2]](diffhunk://#diff-9d1ce4b712e20b08a29f0600e626e6b7ae9449efee473e3e949ebd1626d65942R16)