### PR TITLE
particle system implementation and testing

### DIFF
--- a/engine/src/Core/Application.cc
+++ b/engine/src/Core/Application.cc
@@ -9,6 +9,7 @@
 #include "Defines.hpp"
 #include "Error.hpp"
 #include "Physics/PhysicsSystem.hpp"
+#include "Scene/Systems/ParticleSystem.hpp"
 #include "Scene/Systems/SpriteSystem.hpp"
 #include "Scene/Systems/TransformSystem.hpp"
 
@@ -201,6 +202,12 @@ FeExpect<void, Error> Engine::RegisterSystems() {
   if (!physicsRes.has_value()) {
     FLOG_ERROR("could not register PhysicsSystem into scheduler");
     return FeErr{physicsRes.error()};
+  }
+
+  auto particleRes = _scheduler.Register<systems::ParticleSystem>();
+  if (!particleRes.has_value()) {
+    FLOG_ERROR("could not register ParticleSystem into scheduler");
+    return FeErr{particleRes.error()};
   }
 
   auto buildRes = _scheduler.Build();

--- a/engine/src/Scene/Components/ParticleEmitter.cc
+++ b/engine/src/Scene/Components/ParticleEmitter.cc
@@ -1,0 +1,18 @@
+#include "ParticleEmitter.hpp"
+#include "ECS/Reflect/FieldType.hpp"
+#include "ECS/Reflect/Reflect.hpp"
+
+namespace flatearth::scene {
+
+REFLECT_COMPONENT(ParticleEmitter)
+FIELD(velocityMin, ecs::reflect::FieldType::Vec2D)
+FIELD(velocityMax, ecs::reflect::FieldType::Vec2D)
+FIELD(lifetimeMin, ecs::reflect::FieldType::Float32)
+FIELD(lifetimeMax, ecs::reflect::FieldType::Float32)
+FIELD(sizeStart, ecs::reflect::FieldType::Float32)
+FIELD(sizeEnd, ecs::reflect::FieldType::Float32)
+FIELD(spawnRate, ecs::reflect::FieldType::Float32)
+FIELD(layer, ecs::reflect::FieldType::Uint32)
+END_REFLECT
+
+}

--- a/engine/src/Scene/Components/ParticleEmitter.hpp
+++ b/engine/src/Scene/Components/ParticleEmitter.hpp
@@ -1,0 +1,40 @@
+#ifndef _FLATEARTH_ENGINE_SCENE_COMPONENTS_PARTICLE_EMITTER_HPP
+#define _FLATEARTH_ENGINE_SCENE_COMPONENTS_PARTICLE_EMITTER_HPP
+
+#include "ECS/ECSTypes.hpp"
+#include "Math/Vector2D.hpp"
+#include "Renderer/RendererTypes.hpp"
+#include "Resources/ResourceTypes.hpp"
+#include <array>
+
+namespace flatearth::scene {
+
+constexpr uint32 cMaxParticles = 128;
+
+struct ParticleEmitter {
+  math::Vec2D velocityMin{-1.0f, -1.0f};
+  math::Vec2D velocityMax{1.0f, 1.0f};
+  float32 lifetimeMin{0.5f};
+  float32 lifetimeMax{0.5f};
+  float32 sizeStart{0.15f};
+  float32 sizeEnd{0.0f};
+  float32 spawnRate{10.0f};
+  renderer::RenderLayer layer{renderer::RenderLayer::Effects};
+
+  // Runtime: not serializable
+  std::array<ecs::EntityId, cMaxParticles> pool{};
+  std::array<float32, cMaxParticles> velX{};
+  std::array<float32, cMaxParticles> velY{};
+  std::array<float32, cMaxParticles> lifetime{};
+  std::array<float32, cMaxParticles> elapsed{};
+  std::array<bool, cMaxParticles> active{};
+  float32 spawnAccum{0.0f};
+  bool initialized{FeFalse};
+  resources::TextureHandle texHandle{0};
+  resources::MaterialHandle matHandle{0};
+  resources::MeshHandle meshHandle{0};
+};
+
+}
+
+#endif // _FLATEARTH_ENGINE_SCENE_COMPONENTS_PARTICLE_EMITTER_HPP

--- a/engine/src/Scene/Systems/ParticleSystem.cc
+++ b/engine/src/Scene/Systems/ParticleSystem.cc
@@ -1,0 +1,113 @@
+#include "ParticleSystem.hpp"
+
+#include "Scene/Components/ParticleEmitter.hpp"
+#include "Scene/Components/Sprite.hpp"
+
+#include <cstdlib>
+
+namespace flatearth::systems {
+
+using namespace ecs;
+using namespace scene;
+
+void ParticleSystem::Update(Registry &reg, float32 deltaTime) {
+  View<ParticleEmitter, Transform2D> view = reg.ViewOf<ParticleEmitter, Transform2D>();
+
+  for (auto &&[entity, emitter, transform] : view) {
+    if (!emitter.initialized) {
+      InitPool(reg, emitter, deltaTime);
+    }
+
+    SpawnParticles(reg, emitter, transform, deltaTime);
+    UpdateParticles(reg, emitter, deltaTime);
+  }
+}
+
+void ParticleSystem::InitPool(Registry &reg, ParticleEmitter &emitter, float32 deltaTime) {
+  for (uint32 i = 0; i < cMaxParticles; i++) {
+    EntityId id = reg.Create();
+
+    Transform2D xform{};
+    xform.scaleX = xform.scaleY = 0.0f;
+
+    Sprite sprite{};
+    sprite.texHandle = emitter.texHandle;
+    sprite.matHandle = emitter.matHandle;
+    sprite.meshHandle = emitter.meshHandle;
+    sprite.layer = emitter.layer;
+    sprite.uvOffset = {0.0f, 0.0f};
+    sprite.uvScale = {1.0f, 1.0f};
+
+    reg.Insert(id, xform);
+    reg.Insert(id, sprite);
+
+    emitter.pool[i] = id;
+    emitter.active[i] = FeFalse;
+  }
+
+  emitter.initialized = FeTrue;
+}
+
+void ParticleSystem::SpawnParticles(Registry &reg,
+                                    ParticleEmitter &emitter,
+                                    const Transform2D &origin,
+                                    float32 deltaTime) {
+  emitter.spawnAccum += emitter.spawnRate * deltaTime;
+  uint32 toSpawn = static_cast<uint32>(emitter.spawnAccum);
+  emitter.spawnAccum -= static_cast<float32>(toSpawn);
+
+  uint32 spawned = 0;
+  for (uint32 i = 0; i < cMaxParticles && spawned < toSpawn; i++) {
+    if (emitter.active[i]) {
+      continue;
+    }
+
+    emitter.active[i] = FeTrue;
+    emitter.elapsed[i] = 0.0f;
+    emitter.lifetime[i] = RandRange(emitter.lifetimeMin, emitter.lifetimeMax);
+    emitter.velX[i] = RandRange(emitter.velocityMin.x(), emitter.velocityMax.x());
+    emitter.velY[i] = RandRange(emitter.velocityMin.y(), emitter.velocityMax.y());
+
+    auto &xform = reg.Get<Transform2D>(emitter.pool[i]);
+    xform.x = origin.worldX;
+    xform.y = origin.worldY;
+    xform.scaleX = emitter.sizeStart;
+    xform.scaleY = emitter.sizeStart;
+    xform.dirty = FeTrue;
+    spawned++;
+  }
+}
+
+void ParticleSystem::UpdateParticles(Registry &reg, ParticleEmitter &emitter, float32 deltaTime) {
+  for (uint32 i = 0; i < cMaxParticles; i++) {
+    if (!emitter.active[i]) {
+      continue;
+    }
+
+    emitter.elapsed[i] += deltaTime;
+    if (emitter.elapsed[i] >= emitter.lifetime[i]) {
+      emitter.active[i] = FeFalse;
+      auto &xform = reg.Get<Transform2D>(emitter.pool[i]);
+      xform.scaleX = 0.0f;
+      xform.scaleY = 0.0f;
+      xform.dirty = FeTrue;
+      continue;
+    }
+
+    float32 t = emitter.elapsed[i] / emitter.lifetime[i];
+    float32 size = emitter.sizeStart + (emitter.sizeEnd - emitter.sizeStart) * t;
+
+    auto &xform = reg.Get<Transform2D>(emitter.pool[i]);
+    xform.x += emitter.velX[i] * deltaTime;
+    xform.y += emitter.velY[i] * deltaTime;
+    xform.scaleX = size;
+    xform.scaleY = size;
+    xform.dirty = FeTrue;
+  }
+}
+
+float32 ParticleSystem::RandRange(float32 lo, float32 hi) {
+  return lo + (hi - lo) * (static_cast<float32>(std::rand()) / static_cast<float32>(RAND_MAX));
+}
+
+} // namespace flatearth::systems

--- a/engine/src/Scene/Systems/ParticleSystem.hpp
+++ b/engine/src/Scene/Systems/ParticleSystem.hpp
@@ -1,0 +1,29 @@
+#ifndef _FLATEARTH_ENGINE_SCENE_SYSTEMS_PARTICLE_SYSTEM_HPP
+#define _FLATEARTH_ENGINE_SCENE_SYSTEMS_PARTICLE_SYSTEM_HPP
+
+#include "ECS/Registry.hpp"
+#include "ECS/SystemInterface.hpp"
+#include "Scene/Components/ParticleEmitter.hpp"
+#include "Scene/Components/Transform2D.hpp"
+
+namespace flatearth::systems {
+
+class ParticleSystem : public ecs::ISystem {
+public:
+  void Update(ecs::Registry &registry, float32 deltaTime) override;
+
+private:
+  void InitPool(ecs::Registry &reg, scene::ParticleEmitter &emitter,
+                float32 deltaTime);
+  void SpawnParticles(ecs::Registry &reg, scene::ParticleEmitter &emitter,
+                      const scene::Transform2D &origin, float32 deltaTime);
+  void UpdateParticles(ecs::Registry &reg, scene::ParticleEmitter &emitter,
+                       float32 deltaTime);
+
+private:
+  static float32 RandRange(float32 lo, float32 hi);
+};
+
+}
+
+#endif // _FLATEARTH_ENGINE_SCENE_SYSTEMS_PARTICLE_SYSTEM_HPP

--- a/testbed/src/Game.cc
+++ b/testbed/src/Game.cc
@@ -2,6 +2,7 @@
 
 #include <Core/EngineContext.hpp>
 #include <Core/Input.hpp>
+#include <Scene/Components/ParticleEmitter.hpp>
 #include <Core/Logger.hpp>
 #include <Defines.hpp>
 #include <Scene/Components/Camera2D.hpp>
@@ -92,6 +93,32 @@ bool GameTest::GameLoad(flatearth::Game *gameInstance) {
   _state.playerEntity = playerRes.value();
   pScene->allEntities.push_back(_state.playerEntity);
 
+  auto particleTexRes = ctx.assets.manager.LoadTexture("assets/textures/Human_Walk.png");
+  if (particleTexRes.has_value()) {
+    auto particleSprRes = ctx.assets.manager.SpriteFromTexture(
+        particleTexRes.value(), "particle_mat", resources::MeshShape::Quad);
+    if (particleSprRes.has_value()) {
+      scene::Sprite &ps = particleSprRes.value();
+
+      scene::ParticleEmitter emitter{};
+      emitter.texHandle   = ps.texHandle;
+      emitter.matHandle   = ps.matHandle;
+      emitter.meshHandle  = ps.meshHandle;
+      emitter.velocityMin = {-0.3f, 0.2f};
+      emitter.velocityMax = { 0.3f, 0.8f};
+      emitter.lifetimeMin = 0.3f;
+      emitter.lifetimeMax = 0.8f;
+      emitter.sizeStart   = 0.04f;
+      emitter.sizeEnd     = 0.0f;
+      emitter.spawnRate   = 15.0f;
+
+      _state.particleEntity = ctx.registry.Create();
+      ctx.registry.Insert(_state.particleEntity, scene::Transform2D{});
+      ctx.registry.Insert(_state.particleEntity, emitter);
+      pScene->allEntities.push_back(_state.particleEntity);
+    }
+  }
+
   return FeTrue;
 }
 
@@ -147,6 +174,13 @@ bool GameTest::GameUpdate(flatearth::Game *gameInstance, float32 deltaTime) {
     sprite.flipY = !sprite.flipY;
 
   sprite.dirty    = FeTrue;
+
+  if (_state.particleEntity != UINT32_MAX) {
+    auto &emitterXform = ctx.registry.Get<scene::Transform2D>(_state.particleEntity);
+    emitterXform.x     = playerXform.x;
+    emitterXform.y     = playerXform.y;
+    emitterXform.dirty = FeTrue;
+  }
 
   playerXform.x += dx * speed * deltaTime;
   playerXform.y += dy * speed * deltaTime;

--- a/testbed/src/Game.hpp
+++ b/testbed/src/Game.hpp
@@ -13,6 +13,7 @@ struct GameState {
   ecs::EntityId cameraEntity{UINT32_MAX};
   ecs::EntityId tilemapRoot{UINT32_MAX};
   ecs::EntityId playerEntity{UINT32_MAX};
+  ecs::EntityId particleEntity{UINT32_MAX};
 };
 
 class GameTest {


### PR DESCRIPTION
This pull request introduces a new particle system to the engine, including a `ParticleEmitter` component, its ECS system implementation, and integration into the testbed game for demonstration. The changes add all necessary code for particle emission, management, and rendering, and demonstrate usage by spawning particles at the player’s position in the testbed.

**New Particle System Implementation:**

* Added the `ParticleEmitter` component, including serializable and runtime fields, to represent particle emission properties and manage a pool of particles (`ParticleEmitter.hpp`, `ParticleEmitter.cc`). [[1]](diffhunk://#diff-7064a7c1c01bc28f7b126b898d710e0fccb6c23df98a77da8ea118d24e04dce4R1-R40) [[2]](diffhunk://#diff-27de58b51d77067ecc5ebd5bf7b27348ce66e6d1b5c10491063d327c61306114R1-R18)
* Implemented the `ParticleSystem` ECS system, handling initialization, spawning, and updating of particles each frame (`ParticleSystem.hpp`, `ParticleSystem.cc`). [[1]](diffhunk://#diff-885fee2e405b70c6284e3ddf7479cd51dca1f5e5683dc166813f43e462ac6485R1-R29) [[2]](diffhunk://#diff-aa041afbcdfcbf97ba9c14a1b58af648a34b1a5ff257f84b25eb1f474e3d9192R1-R113)
* Registered the new `ParticleSystem` with the engine’s system scheduler (`Application.cc`). [[1]](diffhunk://#diff-06014678d18a220dac3c5e4ccb0d7395acf7ff5ef6f1e2e4f4618bc91a8fc07dR12) [[2]](diffhunk://#diff-06014678d18a220dac3c5e4ccb0d7395acf7ff5ef6f1e2e4f4618bc91a8fc07dR207-R212)

**Testbed Game Integration:**

* Added code to create a `ParticleEmitter` entity in the testbed, configure it, and keep its position synced with the player for demonstration (`Game.cc`, `Game.hpp`). [[1]](diffhunk://#diff-cd8c5e92797463a5b1f5fbace0e697f28a5619e7432bc63a2317d3b520676ad8R5) [[2]](diffhunk://#diff-cd8c5e92797463a5b1f5fbace0e697f28a5619e7432bc63a2317d3b520676ad8R96-R121) [[3]](diffhunk://#diff-cd8c5e92797463a5b1f5fbace0e697f28a5619e7432bc63a2317d3b520676ad8R178-R184) [[4]](diffhunk://#diff-1e2534426e3ccf36d1dde3d9c0613869b8b6b923b27c2a2a470282a710d24defR16)