### PR TITLE
ImGui Start Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ release/*
 
 #
 .ignore/*
+imgui.ini
 
 # Visual Studio
 .vs/

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -26,6 +26,8 @@ set(LIBRARY_BASE_PATH "${PROJECT_SOURCE_DIR}/src")
 
 include(FetchContent)
 
+# Box2D
+
 FetchContent_Declare(
     box2d
     GIT_REPOSITORY https://github.com/erincatto/box2d.git
@@ -40,6 +42,8 @@ set(BOX2D_BUILD_DOCS       OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(box2d)
 set_target_properties(box2d PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
+# Tiny XML 2
+
 FetchContent_Declare(
     tinyxml2
     GIT_REPOSITORY https://github.com/leethomason/tinyxml2.git
@@ -51,6 +55,17 @@ set(tinyxml2_BUILD_TESTING OFF CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(tinyxml2)
 set_target_properties(tinyxml2 PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+# ImGui
+
+FetchContent_Declare(
+  imgui
+  GIT_REPOSITORY https://github.com/ocornut/imgui.git
+  GIT_TAG        v1.91.5
+  GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(imgui)
+FetchContent_GetProperties(imgui SOURCE_DIR IMGUI_SOURCE_DIR)
 
 ############################################################################
 #   PROJECT DEFINITIONS
@@ -71,6 +86,21 @@ add_library(${BINARY_NAME} SHARED
 target_include_directories(${BINARY_NAME}
     PUBLIC
         ${LIBRARY_BASE_PATH}
+)
+
+target_sources(${BINARY_NAME} PRIVATE
+    ${IMGUI_SOURCE_DIR}/imgui.cpp
+    ${IMGUI_SOURCE_DIR}/imgui_draw.cpp
+    ${IMGUI_SOURCE_DIR}/imgui_tables.cpp
+    ${IMGUI_SOURCE_DIR}/imgui_widgets.cpp
+    ${IMGUI_SOURCE_DIR}/backends/imgui_impl_vulkan.cpp
+)
+
+target_include_directories(${BINARY_NAME}
+    PRIVATE
+        ${IMGUI_SOURCE_DIR}/backends
+    PUBLIC
+        ${IMGUI_SOURCE_DIR}
 )
 
 ############################################################################

--- a/engine/run.sh
+++ b/engine/run.sh
@@ -56,6 +56,7 @@ if [[ "$type" == "Debug" ]]; then
   cmake -G Ninja \
         -DCMAKE_BUILD_TYPE="$type" \
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+        -DCMAKE_CXX_SCAN_FOR_MODULES=OFF \
         -DCMAKE_CXX_FLAGS_DEBUG="${SAN_FLAGS}" \
         -DCMAKE_C_FLAGS_DEBUG="${SAN_FLAGS}" \
         -S . \
@@ -64,6 +65,7 @@ else
     cmake -G Ninja \
           -DCMAKE_BUILD_TYPE="$type" \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+          -DCMAKE_CXX_SCAN_FOR_MODULES=OFF \
           -S . \
           -B "$buildDir"
 fi

--- a/engine/run.sh
+++ b/engine/run.sh
@@ -33,13 +33,13 @@ echo -e "${CYAN}############################### BUILDING ENGINE ################
 
 # Check build directory
 echo -e "${YELLOW}>> Checking if build directory exists...${RESET}"
+if [ -d "$buildDir" ] && [ ! -f "$buildDir/build.ninja" ]; then
+    echo -e "${YELLOW}Stale build directory (wrong generator) — removing...${RESET}"
+    rm -rf "$buildDir"
+fi
 if [ ! -d "$buildDir" ]; then
     echo -e "${GREEN}Creating build directory...${RESET}"
     mkdir "$buildDir"
-    pushd "$buildDir" > /dev/null
-    echo -e "${CYAN}Running 'cmake ..'${RESET}"
-    cmake ..
-    popd > /dev/null
 else
     echo -e "${GREEN}Build directory exists!${RESET}"
 fi
@@ -53,14 +53,16 @@ if [ -f compile_commands.json ]; then
 fi
 
 if [[ "$type" == "Debug" ]]; then
-  cmake -DCMAKE_BUILD_TYPE="$type" \
+  cmake -G Ninja \
+        -DCMAKE_BUILD_TYPE="$type" \
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
         -DCMAKE_CXX_FLAGS_DEBUG="${SAN_FLAGS}" \
         -DCMAKE_C_FLAGS_DEBUG="${SAN_FLAGS}" \
         -S . \
         -B "$buildDir"
 else
-    cmake -DCMAKE_BUILD_TYPE="$type" \
+    cmake -G Ninja \
+          -DCMAKE_BUILD_TYPE="$type" \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
           -S . \
           -B "$buildDir"
@@ -70,11 +72,6 @@ ln -sf "${linkPath}/${buildDir}/compile_commands.json" compile_commands.json
 
 echo -e "${CYAN}Running CMake build...${RESET}"
 cmake --build "$buildDir"
-
-echo -e "${CYAN}Running make inside build directory...${RESET}"
-pushd "$buildDir" > /dev/null
-make
-popd > /dev/null
 
 # Copying step
 echo -e "${CYAN}############################# COPYING STEP ####################################${RESET}"

--- a/engine/src/Assets/TilemapManager.cc
+++ b/engine/src/Assets/TilemapManager.cc
@@ -1,6 +1,7 @@
 #include "Assets/TilemapManager.hpp"
 
 #include "Assets/AssetManager.hpp"
+#include "Core/FeMemory.hpp"
 #include "Assets/TilemapLoader.hpp"
 #include "Core/Logger.hpp"
 #include "ECS/Registry.hpp"
@@ -13,8 +14,10 @@
 
 namespace flatearth::assets {
 
-TilemapManager::TilemapManager(AssetManager &assetManager, ecs::Registry &registry)
-    : _assetManager(assetManager), _registry(registry) {}
+TilemapManager::TilemapManager(memory::MemoryManager &memManager,
+                               AssetManager &assetManager,
+                               ecs::Registry &registry)
+    : _assetManager(assetManager), _registry(registry), _baseSprites(memManager) {}
 
 FeExpect<ecs::EntityId, Error> TilemapManager::Load(stringv tmxPath, scene::Scene *scene) {
   TilemapLoader loader{_assetManager};
@@ -83,13 +86,12 @@ FeExpect<ecs::EntityId, Error> TilemapManager::Load(stringv tmxPath, scene::Scen
     }
   }
 
+  auto _ = _baseSprites.Insert(string(tmxPath), baseSprite);
+
   uint32 renderLayerCount = static_cast<uint32>(tm.renderLayers.size());
   uint32 collTileCount    = static_cast<uint32>(coll.tiles.size());
   uint32 objectCount      = static_cast<uint32>(tm.objects.size());
 
-  // ── root tilemap entity ───────────────────────────────────────────────────
-  // Tilemap data is not stored as a component (contains std::vector — not trivially copyable).
-  // TilemapManager owns the data; the root entity is just a transform anchor.
   auto root = _registry.Create();
   _registry.Insert(root, scene::Transform2D{});
   scene->roots.push_back(root);
@@ -98,6 +100,14 @@ FeExpect<ecs::EntityId, Error> TilemapManager::Load(stringv tmxPath, scene::Scen
   FLOG_INFO("TilemapManager: loaded '{}' — {} render layers, {} collision tiles, {} objects",
             tmxPath, renderLayerCount, collTileCount, objectCount);
   return root;
+}
+
+void TilemapManager::Unload(stringv tmxPath) {
+  scene::Sprite *pBase = _baseSprites.Retrieve(string(tmxPath));
+  if (pBase) {
+    _assetManager.ReleaseSprite(*pBase);
+    _baseSprites.Erase(string(tmxPath));
+  }
 }
 
 } // namespace flatearth::assets

--- a/engine/src/Assets/TilemapManager.hpp
+++ b/engine/src/Assets/TilemapManager.hpp
@@ -1,9 +1,12 @@
 #ifndef _FLATEARTH_ENGINE_ASSETS_TILEMAP_MANAGER_HPP
 #define _FLATEARTH_ENGINE_ASSETS_TILEMAP_MANAGER_HPP
 
+#include "Containers/HashMap.hpp"
+#include "Core/FeMemory.hpp"
 #include "Defines.hpp"
 #include "Error.hpp"
 #include "ECS/ECSTypes.hpp"
+#include "Scene/Components/Sprite.hpp"
 
 namespace flatearth::scene { struct Scene; }
 namespace flatearth::ecs   { class Registry; }
@@ -14,16 +17,17 @@ class AssetManager;
 
 class TilemapManager {
 public:
-  explicit TilemapManager(AssetManager &assetManager, ecs::Registry &registry);
+  explicit TilemapManager(memory::MemoryManager &memManager,
+                          AssetManager &assetManager,
+                          ecs::Registry &registry);
 
-  // Loads a .tmx file, creates all tile and collision entities, registers them
-  // in the scene for automatic cleanup on SceneManager::Unload.
-  // Returns the root tilemap entity.
   FEAPI FeExpect<ecs::EntityId, Error> Load(stringv tmxPath, scene::Scene *scene);
+  FEAPI void Unload(stringv tmxPath);
 
 private:
   AssetManager   &_assetManager;
   ecs::Registry  &_registry;
+  containers::HashMap<string, scene::Sprite> _baseSprites;
 };
 
 } // namespace flatearth::assets

--- a/engine/src/Core/Application.cc
+++ b/engine/src/Core/Application.cc
@@ -179,6 +179,7 @@ FeExpect<void, Error> Engine::Start() {
       FLOG_ERROR("game renderer failed to draw frame: {}", drawRes.error().message);
       return FeErr{drawRes.error()};
     }
+    _ctx.drawCallCount = _renderer.LastDrawCallCount();
 
     float64 frameEndTime = clock::GetAbsoluteTime();
     float64 frameElapsed = frameEndTime - frameStartTime;

--- a/engine/src/Core/Application.cc
+++ b/engine/src/Core/Application.cc
@@ -20,7 +20,7 @@ namespace flatearth {
 Engine::Engine(Game *pGame)
     : _appState(pGame), _eventManager(_memoryManager), _inputManager(_eventManager),
       _renderer(&_appState, _memoryManager, _registry, _filesystem), _filesystem(_memoryManager),
-      _assetManager(_memoryManager, _filesystem), _tilemapManager(_assetManager, _registry),
+      _assetManager(_memoryManager, _filesystem), _tilemapManager(_memoryManager, _assetManager, _registry),
       _prefabManager(_memoryManager), _scheduler(_memoryManager),
       _registry(_memoryManager), _sceneManager(_memoryManager, _registry), _world(_memoryManager),
       _ctx(_memoryManager,
@@ -36,6 +36,7 @@ Engine::Engine(Game *pGame)
 }
 
 Engine::~Engine() {
+  _renderer.Flush();
   if (_appState.pGameInstance->Unload) {
     _appState.pGameInstance->Unload(_appState.pGameInstance);
   }

--- a/engine/src/Core/Application.cc
+++ b/engine/src/Core/Application.cc
@@ -1,5 +1,7 @@
 #include "Application.hpp"
 
+#include <imgui.h>
+
 #include "Core/Clock.hpp"
 #include "Core/EngineListener.hpp"
 #include "Core/Event.hpp"
@@ -153,6 +155,24 @@ FeExpect<void, Error> Engine::Start() {
     }
 
     _scheduler.Update(_registry, deltaTime);
+
+    _renderer.BeginImGuiFrame();
+    ImGuiIO &io = ImGui::GetIO();
+    io.DisplaySize = ImVec2(static_cast<float>(_appState.width),
+                            static_cast<float>(_appState.height));
+    io.DeltaTime   = static_cast<float>(deltaTime);
+    int32 mx, my;
+    _inputManager.GetMousePosition(mx, my);
+    io.AddMousePosEvent(static_cast<float>(mx), static_cast<float>(my));
+    io.AddMouseButtonEvent(0, _inputManager.IsButtonDown(input::Button::Left));
+    io.AddMouseButtonEvent(1, _inputManager.IsButtonDown(input::Button::Right));
+    io.AddMouseButtonEvent(2, _inputManager.IsButtonDown(input::Button::Middle));
+    ImGui::NewFrame();
+    if (_appState.pGameInstance->OnImGui) {
+      _appState.pGameInstance->OnImGui(_appState.pGameInstance);
+    }
+    ImGui::Render();
+
     auto drawRes = _renderer.Draw(deltaTime);
     if (!drawRes.has_value()) {
       FLOG_ERROR("game renderer failed to draw frame: {}", drawRes.error().message);

--- a/engine/src/Core/EngineContext.hpp
+++ b/engine/src/Core/EngineContext.hpp
@@ -27,6 +27,7 @@ struct EngineContext {
   ecs::Registry &registry;
   scene::SceneManager &sceneManager;
   physics::FlatearthWorld &world;
+  uint32 drawCallCount{0};
 
   explicit EngineContext(memory::MemoryManager &memManager,
                          assets::AssetManager &assetManager,

--- a/engine/src/Core/FeMemory.cc
+++ b/engine/src/Core/FeMemory.cc
@@ -21,7 +21,6 @@ static inline uint64 NormalizeAlignment(uint64 alignment) {
   return alignment;
 }
 
-static const char *TagToString(flatearth::memory::Tag tag);
 
 struct MemFmt {
   uint64 bytes;
@@ -141,13 +140,13 @@ void MemoryManager::MemoryUsage() {
     Tag tag = static_cast<Tag>(i);
 
     std::println(
-        "  [{}] {} bytes ({:.2f} KB | {:.2f} MB)", TagToString(tag), fmt.bytes, fmt.kb, fmt.mb);
+        "  [{}] {} bytes ({:.2f} KB | {:.2f} MB)", TagName(tag), fmt.bytes, fmt.kb, fmt.mb);
   }
 
   std::println("==================================");
 }
 
-const char *TagToString(flatearth::memory::Tag tag) {
+const char *TagName(flatearth::memory::Tag tag) {
   using flatearth::memory::Tag;
   switch (tag) {
     case Tag::Unknown:
@@ -188,6 +187,8 @@ const char *TagToString(flatearth::memory::Tag tag) {
       return "EntityNode";
     case Tag::Scene:
       return "Scene";
+    case Tag::HashMap:
+      return "HashMap";
     default:
       return "Invalid";
   }

--- a/engine/src/Core/FeMemory.hpp
+++ b/engine/src/Core/FeMemory.hpp
@@ -85,10 +85,13 @@ public:
   }
 
   void MemoryUsage();
+  const SystemState &GetStats() const { return _memoryState; }
 
 private:
   SystemState _memoryState{};
 };
+
+FEAPI const char *TagName(Tag tag);
 
 } // namespace flatearth::memory
 

--- a/engine/src/Core/Input.cc
+++ b/engine/src/Core/Input.cc
@@ -102,4 +102,14 @@ bool InputManager::WasButtonUp(Button button) {
   return !_state.mousePrevious.buttons[ButtonIndex(button)];
 }
 
+void InputManager::GetMousePosition(int32 &x, int32 &y) {
+  x = _state.mouseCurrent.x;
+  y = _state.mouseCurrent.y;
+}
+
+void InputManager::GetPreviousMousePosition(int32 &x, int32 &y) {
+  x = _state.mousePrevious.x;
+  y = _state.mousePrevious.y;
+}
+
 } // namespace flatearth::input

--- a/engine/src/ECS/Registry.hpp
+++ b/engine/src/ECS/Registry.hpp
@@ -72,6 +72,8 @@ public:
     return View<Ts...>(GetPool<Ts>()...);
   }
 
+  uint32 AliveCount() const { return _entityManager.AliveCount(); }
+
 private:
   memory::MemoryManager &_memoryManager;
   EntityManager _entityManager;

--- a/engine/src/GameTypes.hpp
+++ b/engine/src/GameTypes.hpp
@@ -22,14 +22,15 @@ public:
   std::function<void(struct Game *gameInstance)> Unload;
   std::function<bool(struct Game *gameInstance, float32 deltaTime)> Update;
   std::function<bool(struct Game *gameInstance, uint32 width, uint32 height)> OnResize;
+  std::function<void(struct Game *gameInstance)> OnImGui;
 
   explicit Game()
-      : Initialize(nullptr), Load(nullptr), Unload(nullptr), Update(nullptr), OnResize(nullptr),
+      : Initialize(nullptr), Load(nullptr), Unload(nullptr), Update(nullptr), OnResize(nullptr), OnImGui(nullptr),
         gameName(cGameName), windowStartWidth(scDefaultStartWidth),
         windowStartHeight(scDefaultStartHeight) {}
 
   Game(const string &name)
-      : Initialize(nullptr), Load(nullptr), Unload(nullptr), Update(nullptr), OnResize(nullptr),
+      : Initialize(nullptr), Load(nullptr), Unload(nullptr), Update(nullptr), OnResize(nullptr), OnImGui(nullptr),
         gameName(name), windowStartWidth(scDefaultStartWidth),
         windowStartHeight(scDefaultStartHeight) {}
 

--- a/engine/src/Renderer/GameRenderer.cc
+++ b/engine/src/Renderer/GameRenderer.cc
@@ -62,6 +62,10 @@ FeExpect<bool, Error> GameRenderer::Draw(float32 deltaTime) {
   return _frontendRenderer.DrawFrame(&packet);
 }
 
+void GameRenderer::Flush() {
+  _frontendRenderer.Flush();
+}
+
 void GameRenderer::BeginImGuiFrame() {
   _frontendRenderer.BeginImGuiFrame();
 }

--- a/engine/src/Renderer/GameRenderer.cc
+++ b/engine/src/Renderer/GameRenderer.cc
@@ -59,6 +59,7 @@ FeExpect<bool, Error> GameRenderer::Draw(float32 deltaTime) {
     packet.objects.Push(object);
   }
 
+  _lastDrawCallCount = packet.objects.Length();
   return _frontendRenderer.DrawFrame(&packet);
 }
 

--- a/engine/src/Renderer/GameRenderer.cc
+++ b/engine/src/Renderer/GameRenderer.cc
@@ -62,6 +62,10 @@ FeExpect<bool, Error> GameRenderer::Draw(float32 deltaTime) {
   return _frontendRenderer.DrawFrame(&packet);
 }
 
+void GameRenderer::BeginImGuiFrame() {
+  _frontendRenderer.BeginImGuiFrame();
+}
+
 FrontendRenderer &GameRenderer::FrontendReference() {
   return _frontendRenderer;
 }

--- a/engine/src/Renderer/GameRenderer.hpp
+++ b/engine/src/Renderer/GameRenderer.hpp
@@ -14,6 +14,8 @@ public:
 
   FeExpect<bool, Error> Initialize();
   FeExpect<bool, Error> Draw(float32 deltaTime);
+  void BeginImGuiFrame();
+
   void Shutdown();
 
   FrontendRenderer &FrontendReference();

--- a/engine/src/Renderer/GameRenderer.hpp
+++ b/engine/src/Renderer/GameRenderer.hpp
@@ -19,12 +19,14 @@ public:
   void Flush();
   void Shutdown();
 
+  uint32 LastDrawCallCount() const { return _lastDrawCallCount; }
   FrontendRenderer &FrontendReference();
 
 private:
   renderer::FrontendRenderer _frontendRenderer;
   memory::MemoryManager &_memoryManager;
   ecs::Registry &_registry;
+  uint32 _lastDrawCallCount{0};
 };
 
 } // namespace flatearth::renderer

--- a/engine/src/Renderer/GameRenderer.hpp
+++ b/engine/src/Renderer/GameRenderer.hpp
@@ -16,6 +16,7 @@ public:
   FeExpect<bool, Error> Draw(float32 deltaTime);
   void BeginImGuiFrame();
 
+  void Flush();
   void Shutdown();
 
   FrontendRenderer &FrontendReference();

--- a/engine/src/Renderer/RendererFrontend.cc
+++ b/engine/src/Renderer/RendererFrontend.cc
@@ -133,6 +133,8 @@ FeExpect<bool, Error> FrontendRenderer::DrawFrame(RenderPacket *pRenderPacket) {
     _rendererState.pActiveBackend->DrawGeometry(object.geometryId, data, object.pMaterial);
   }
 
+  _rendererState.pActiveBackend->DrawImGui();
+
   auto endRes = EndFrame(pRenderPacket->deltaTime);
   if (!endRes.has_value()) {
     FLOG_ERROR("failed to end frame");
@@ -224,6 +226,10 @@ void FrontendRenderer::ReleaseMaterial(resources::MaterialHandle handle) {
 
 resources::Material *FrontendRenderer::GetMaterial(resources::MaterialHandle handle) {
   return _materialCache.Get(handle);
+}
+
+void FrontendRenderer::BeginImGuiFrame() {
+  _rendererState.pActiveBackend->BeginImGuiFrame();
 }
 
 FeExpect<void, Error> FrontendRenderer::MakeBackends() {

--- a/engine/src/Renderer/RendererFrontend.cc
+++ b/engine/src/Renderer/RendererFrontend.cc
@@ -25,10 +25,14 @@ FrontendRenderer::~FrontendRenderer() {
   FLOG_INFO("frontend renderer exited gracefully");
 }
 
-void FrontendRenderer::Shutdown() {
+void FrontendRenderer::Flush() {
   if (_rendererState.pActiveBackend) {
     _rendererState.pActiveBackend->Flush();
   }
+}
+
+void FrontendRenderer::Shutdown() {
+  Flush();
   _meshCache.Shutdown();
   _materialCache.Shutdown();
 }

--- a/engine/src/Renderer/RendererFrontend.cc
+++ b/engine/src/Renderer/RendererFrontend.cc
@@ -26,6 +26,9 @@ FrontendRenderer::~FrontendRenderer() {
 }
 
 void FrontendRenderer::Shutdown() {
+  if (_rendererState.pActiveBackend) {
+    _rendererState.pActiveBackend->Flush();
+  }
   _meshCache.Shutdown();
   _materialCache.Shutdown();
 }

--- a/engine/src/Renderer/RendererFrontend.hpp
+++ b/engine/src/Renderer/RendererFrontend.hpp
@@ -43,29 +43,31 @@ public:
                 resources::TextureFilter filter = resources::TextureFilter::Nearest);
   FeExpect<void, Error> DestroyTexture(resources::Texture *pTexture);
 
-  FEAPI FeExpect<void, Error> CreateMaterial(resources::Material *pMaterial,
-                                             const resources::Texture *pTexture);
-  FEAPI FeExpect<void, Error> DestroyMaterial(resources::Material *pMaterial);
+  FeExpect<void, Error> CreateMaterial(resources::Material *pMaterial,
+                                       const resources::Texture *pTexture);
+  FeExpect<void, Error> DestroyMaterial(resources::Material *pMaterial);
 
-  FEAPI FeExpect<void, Error> CreateGeometry(uint32 id,
-                                             uint32 vertexCount,
-                                             const math::Vertex3D *pVertices,
-                                             uint32 indexCount,
-                                             const uint32 *pIndices);
-  FEAPI FeExpect<void, Error> DestroyGeometry(uint32 id);
+  FeExpect<void, Error> CreateGeometry(uint32 id,
+                                       uint32 vertexCount,
+                                       const math::Vertex3D *pVertices,
+                                       uint32 indexCount,
+                                       const uint32 *pIndices);
+  FeExpect<void, Error> DestroyGeometry(uint32 id);
 
   // Mesh cache public API
-  FEAPI FeExpect<resources::MeshHandle, Error> AcquireMesh(resources::MeshShape shape);
-  FEAPI void ReleaseMesh(resources::MeshHandle handle);
-  FEAPI resources::Mesh *GetMesh(resources::MeshHandle handle);
+  FeExpect<resources::MeshHandle, Error> AcquireMesh(resources::MeshShape shape);
+  void ReleaseMesh(resources::MeshHandle handle);
+  resources::Mesh *GetMesh(resources::MeshHandle handle);
 
   // Material cache public API
-  FEAPI FeExpect<resources::MaterialHandle, Error> AcquireMaterial(const string &name,
-                                                                    resources::Texture *pTexture);
-  FEAPI void ReleaseMaterial(resources::MaterialHandle handle);
-  FEAPI resources::Material *GetMaterial(resources::MaterialHandle handle);
+  FeExpect<resources::MaterialHandle, Error> AcquireMaterial(const string &name,
+                                                             resources::Texture *pTexture);
+  void ReleaseMaterial(resources::MaterialHandle handle);
+  resources::Material *GetMaterial(resources::MaterialHandle handle);
 
-  FEAPI void Shutdown();
+  void BeginImGuiFrame();
+
+  void Shutdown();
 
 private:
   FeExpect<void, Error> MakeBackends();

--- a/engine/src/Renderer/RendererFrontend.hpp
+++ b/engine/src/Renderer/RendererFrontend.hpp
@@ -65,6 +65,7 @@ public:
   void ReleaseMaterial(resources::MaterialHandle handle);
   resources::Material *GetMaterial(resources::MaterialHandle handle);
 
+  void Flush();
   void BeginImGuiFrame();
 
   void Shutdown();

--- a/engine/src/Renderer/RendererInterface.hpp
+++ b/engine/src/Renderer/RendererInterface.hpp
@@ -51,6 +51,9 @@ public:
                                                const resources::Texture *pTexture) = 0;
   virtual FeExpect<void, Error> DestroyMaterial(resources::Material *pMaterial) = 0;
 
+  virtual void BeginImGuiFrame() {}
+  virtual void DrawImGui() {}
+
 protected:
   virtual ~IRendererBackend() = default;
 };

--- a/engine/src/Renderer/RendererInterface.hpp
+++ b/engine/src/Renderer/RendererInterface.hpp
@@ -51,6 +51,7 @@ public:
                                                const resources::Texture *pTexture) = 0;
   virtual FeExpect<void, Error> DestroyMaterial(resources::Material *pMaterial) = 0;
 
+  virtual void Flush() {}
   virtual void BeginImGuiFrame() {}
   virtual void DrawImGui() {}
 

--- a/engine/src/Renderer/Vulkan/VulkanBackend.cc
+++ b/engine/src/Renderer/Vulkan/VulkanBackend.cc
@@ -10,6 +10,8 @@
 #include "Renderer/Vulkan/VulkanUtils.hpp"
 #include "Resources/ResourceTypes.hpp"
 
+#include <imgui.h>
+#include <backends/imgui_impl_vulkan.h>
 #include <cstdint>
 #include <vulkan/vulkan_core.h>
 
@@ -29,6 +31,7 @@ VulkanBackend::VulkanBackend(memory::MemoryManager &memManager, platform::FileSy
 }
 
 VulkanBackend::~VulkanBackend() {
+  ShutdownImGui();
   vkDeviceWaitIdle(_ctx.device.logicalDevice);
 
   _bufferManager.DestroyVulkanBuffer(_ctx, &_ctx.objectVertexBuffer);
@@ -334,6 +337,8 @@ FeExpect<bool, Error> VulkanBackend::Initialize(ApplicationState *appState) {
     FLOG_ERROR("vulkan buffers creation failed");
     return FeErr{createBufferRes.error()};
   }
+
+  InitImGui();
 
   FLOG_INFO("sync objects & fences created successfully");
   FLOG_INFO("Vulkan backend initialized successfully");
@@ -844,6 +849,15 @@ FeExpect<void, Error> VulkanBackend::DestroyMaterial(resources::Material *pMater
   return {};
 }
 
+void VulkanBackend::BeginImGuiFrame() {
+  ImGui_ImplVulkan_NewFrame();
+}
+
+void VulkanBackend::DrawImGui() {
+  CommandBuffer &cmd = _ctx.graphicsCommandBuffer[_ctx.imageIndex];
+  ImGui_ImplVulkan_RenderDrawData(ImGui::GetDrawData(), cmd.handle);
+}
+
 // PRIVATE MEMBERS
 
 FeExpect<void, Error> VulkanBackend::CreateFence(Fence *pFence, bool signaled) {
@@ -1046,6 +1060,53 @@ void VulkanBackend::TextureSubmitCallback(CommandBuffer cmd,
     FLOG_ERROR("failed to transition image layout for texture upload");
     return;
   }
+}
+
+void VulkanBackend::InitImGui() {
+  VkDescriptorPoolSize poolSize{VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 100};
+  VkDescriptorPoolCreateInfo poolInfo{};
+  poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+  poolInfo.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
+  poolInfo.maxSets = 100;
+  poolInfo.poolSizeCount = 1;
+  poolInfo.pPoolSizes = &poolSize;
+  vkCreateDescriptorPool(_ctx.device.logicalDevice, &poolInfo, nullptr, &_imguiDescriptorPool);
+
+  IMGUI_CHECKVERSION();
+  ImGui::CreateContext();
+  ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+  ImGui::StyleColorsDark();
+
+  ImGui_ImplVulkan_InitInfo initInfo{};
+  initInfo.Instance = _ctx.instance;
+  initInfo.PhysicalDevice = _ctx.device.physicalDevice;
+  initInfo.Device = _ctx.device.logicalDevice;
+  initInfo.QueueFamily = static_cast<uint32>(_ctx.device.graphicsQueueIndex);
+  initInfo.Queue = _ctx.device.graphicsQueue;
+  initInfo.DescriptorPool = _imguiDescriptorPool;
+  initInfo.RenderPass = _ctx.mainRenderpass.handle;
+  initInfo.Subpass = 0;
+  initInfo.MinImageCount = _ctx.swapchain.maxFrames;
+  initInfo.ImageCount = _ctx.swapchain.imageCount;
+  initInfo.MSAASamples = VK_SAMPLE_COUNT_1_BIT;
+  initInfo.CheckVkResultFn = [](VkResult err) {
+    if (err != VK_SUCCESS) {
+      FLOG_ERROR("ImGui Vulkan Error: {}", static_cast<int32>(err));
+    }
+  };
+  ImGui_ImplVulkan_Init(&initInfo);
+  FLOG_INFO("ImGui initialized with Vulkan Implementation");
+}
+
+void VulkanBackend::ShutdownImGui() {
+  if (_imguiDescriptorPool == VK_NULL_HANDLE) {
+    return;
+  }
+
+  ImGui_ImplVulkan_Shutdown();
+  ImGui::DestroyContext();
+  vkDestroyDescriptorPool(_ctx.device.logicalDevice, _imguiDescriptorPool, nullptr);
+  _imguiDescriptorPool = VK_NULL_HANDLE;
 }
 
 VKAPI_ATTR VkBool32 VKAPI_CALL

--- a/engine/src/Renderer/Vulkan/VulkanBackend.cc
+++ b/engine/src/Renderer/Vulkan/VulkanBackend.cc
@@ -31,8 +31,8 @@ VulkanBackend::VulkanBackend(memory::MemoryManager &memManager, platform::FileSy
 }
 
 VulkanBackend::~VulkanBackend() {
-  ShutdownImGui();
   vkDeviceWaitIdle(_ctx.device.logicalDevice);
+  ShutdownImGui();
 
   _bufferManager.DestroyVulkanBuffer(_ctx, &_ctx.objectVertexBuffer);
   _bufferManager.DestroyVulkanBuffer(_ctx, &_ctx.objectIndexBuffer);
@@ -847,6 +847,10 @@ FeExpect<void, Error> VulkanBackend::DestroyMaterial(resources::Material *pMater
   _memoryManager.RawFree(pMatData, sizeof(MaterialData), memory::Tag::Renderer);
   pMaterial->pInternalData = nullptr;
   return {};
+}
+
+void VulkanBackend::Flush() {
+  vkDeviceWaitIdle(_ctx.device.logicalDevice);
 }
 
 void VulkanBackend::BeginImGuiFrame() {

--- a/engine/src/Renderer/Vulkan/VulkanBackend.hpp
+++ b/engine/src/Renderer/Vulkan/VulkanBackend.hpp
@@ -55,6 +55,9 @@ public:
                                        const resources::Texture *pTexture) override;
   FeExpect<void, Error> DestroyMaterial(resources::Material *pMaterial) override;
 
+  void BeginImGuiFrame() override;
+  void DrawImGui() override;
+
 private:
   FeExpect<void, Error> CreateFence(Fence *pFence, bool signaled);
   FeExpect<void, Error> DestroyFence(Fence *pFence);
@@ -68,6 +71,9 @@ private:
                                         uint64 size,
                                         VulkanBuffer &buffer,
                                         const void *pData);
+
+  void InitImGui();
+  void ShutdownImGui();
 
   void TextureSubmitCallback(CommandBuffer cmd,
                              VkFormat imageFormat,
@@ -87,6 +93,8 @@ private:
   Context _ctx;
 
   containers::HashMap<uint32, GeometryData> _geometries;
+
+  VkDescriptorPool _imguiDescriptorPool{VK_NULL_HANDLE};
 
   const resources::Material *_cpLastBoundMaterial{nullptr};
   uint32 _lastBoundGeometry{UINT32_MAX};

--- a/engine/src/Renderer/Vulkan/VulkanBackend.hpp
+++ b/engine/src/Renderer/Vulkan/VulkanBackend.hpp
@@ -55,6 +55,7 @@ public:
                                        const resources::Texture *pTexture) override;
   FeExpect<void, Error> DestroyMaterial(resources::Material *pMaterial) override;
 
+  void Flush() override;
   void BeginImGuiFrame() override;
   void DrawImGui() override;
 

--- a/testbed/CMakeLists.txt
+++ b/testbed/CMakeLists.txt
@@ -65,6 +65,7 @@ if(UNIX AND NOT APPLE AND NOT TARGET flatearth)
 
     target_include_directories(flatearth INTERFACE
         "${CMAKE_CURRENT_LIST_DIR}/../engine/src"
+        "${FLATEARTH_ENGINE_BUILD_DIR}/_deps/imgui-src"
     )
 endif()
 

--- a/testbed/run.sh
+++ b/testbed/run.sh
@@ -17,6 +17,10 @@ linkPath=$(pwd)
 testingPath=$(pwd)
 binDir="../${OUT_ROOT}/bin"
 
+if [ -d "$buildDir" ] && [ ! -f "$buildDir/build.ninja" ]; then
+  echo -e "${YELLOW}Stale build directory (wrong generator) — removing...${RESET}"
+  rm -rf "$buildDir"
+fi
 mkdir -p "$buildDir"
 mkdir -p "$binDir"
 
@@ -32,7 +36,8 @@ if [ -f compile_commands.json ]; then
   rm compile_commands.json
 fi
 
-cmake -DCMAKE_BUILD_TYPE="$type" \
+cmake -G Ninja \
+      -DCMAKE_BUILD_TYPE="$type" \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
       -S . \
       -B "$buildDir"

--- a/testbed/run.sh
+++ b/testbed/run.sh
@@ -39,6 +39,7 @@ fi
 cmake -G Ninja \
       -DCMAKE_BUILD_TYPE="$type" \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+      -DCMAKE_CXX_SCAN_FOR_MODULES=OFF \
       -S . \
       -B "$buildDir"
 

--- a/testbed/src/Entrypoint.cc
+++ b/testbed/src/Entrypoint.cc
@@ -13,6 +13,7 @@ bool CreateGame(flatearth::Game *pGame) {
   pGame->Unload = GameTest::GameUnload;
   pGame->Update = GameTest::GameUpdate;
   pGame->OnResize = GameTest::GameOnResize;
+  pGame->OnImGui  = GameTest::GameImGui;
   return true;
 }
 

--- a/testbed/src/Game.cc
+++ b/testbed/src/Game.cc
@@ -3,6 +3,8 @@
 #include <Core/EngineContext.hpp>
 #include <Core/Input.hpp>
 #include <Scene/Components/ParticleEmitter.hpp>
+#include <Core/FeMemory.hpp>
+#include <imgui.h>
 #include <Core/Logger.hpp>
 #include <Defines.hpp>
 #include <Scene/Components/Camera2D.hpp>
@@ -191,6 +193,39 @@ bool GameTest::GameUpdate(flatearth::Game *gameInstance, float32 deltaTime) {
   cameraXform.dirty = FeTrue;
 
   return FeTrue;
+}
+
+// TODO: remove, just here for testing
+void GameTest::GameImGui(flatearth::Game *gameInstance) {
+  EngineContext &ctx = *gameInstance->pCtx;
+
+  ImGui::Begin("Debug");
+
+  ImGui::Text("FPS: %.1f", 1.0f / ImGui::GetIO().DeltaTime);
+
+  if (ImGui::CollapsingHeader("ECS", ImGuiTreeNodeFlags_DefaultOpen)) {
+    ImGui::Text("Entities alive: %u", ctx.registry.AliveCount());
+    if (_state.playerEntity != UINT32_MAX) {
+      auto &xform = ctx.registry.Get<scene::Transform2D>(_state.playerEntity);
+      ImGui::Text("Player pos: (%.2f, %.2f)", xform.x, xform.y);
+    }
+  }
+
+  if (ImGui::CollapsingHeader("Memory")) {
+    const auto &stats = ctx.core.memory.GetStats();
+    double totalKB = stats.memoryBlock.totalAllocated / 1024.0;
+    double totalMB = totalKB / 1024.0;
+    ImGui::Text("Total: %.2f KB (%.2f MB)", totalKB, totalMB);
+    ImGui::Text("Active allocs: %llu", static_cast<unsigned long long>(stats.allocCount));
+    ImGui::Separator();
+    for (uint64 i = 0; i < memory::MaxTags; ++i) {
+      uint64 bytes = stats.memoryBlock.taggedAllocations[i];
+      if (bytes == 0) continue;
+      ImGui::Text("  [%-16s] %.2f KB", memory::TagName(static_cast<memory::Tag>(i)), bytes / 1024.0);
+    }
+  }
+
+  ImGui::End();
 }
 
 void GameTest::GameUnload(flatearth::Game *gameInstance) {

--- a/testbed/src/Game.cc
+++ b/testbed/src/Game.cc
@@ -211,6 +211,29 @@ void GameTest::GameImGui(flatearth::Game *gameInstance) {
     }
   }
 
+  if (ImGui::CollapsingHeader("Camera", ImGuiTreeNodeFlags_DefaultOpen)) {
+    auto camView = ctx.registry.ViewOf<scene::Transform2D, scene::Camera2D>();
+    for (auto [e, xform, cam] : camView) {
+      ImGui::Text("World pos: (%.2f, %.2f)", xform.worldX, xform.worldY);
+      ImGui::Text("Zoom: %.3f", cam.zoom);
+      break;
+    }
+  }
+
+  if (ImGui::CollapsingHeader("Particles", ImGuiTreeNodeFlags_DefaultOpen)) {
+    auto emitterView = ctx.registry.ViewOf<scene::ParticleEmitter, scene::Transform2D>();
+    int emitterIdx = 0;
+    for (auto [e, emitter, xform] : emitterView) {
+      uint32 activeCount = 0;
+      for (uint32 i = 0; i < scene::cMaxParticles; ++i)
+        activeCount += emitter.active[i] ? 1 : 0;
+      ImGui::Text("Emitter %d: %u / %u active", emitterIdx, activeCount, scene::cMaxParticles);
+      ImGui::Text("  pos: (%.2f, %.2f)  rate: %.1f/s", xform.worldX, xform.worldY, emitter.spawnRate);
+      ++emitterIdx;
+    }
+    if (emitterIdx == 0) ImGui::TextDisabled("no emitters");
+  }
+
   if (ImGui::CollapsingHeader("Memory")) {
     const auto &stats = ctx.core.memory.GetStats();
     double totalKB = stats.memoryBlock.totalAllocated / 1024.0;
@@ -231,6 +254,22 @@ void GameTest::GameImGui(flatearth::Game *gameInstance) {
 void GameTest::GameUnload(flatearth::Game *gameInstance) {
   if (!gameInstance->pCtx) return;
   EngineContext &ctx = *gameInstance->pCtx;
+
+  if (_state.playerEntity != UINT32_MAX) {
+    auto &sprite = ctx.registry.Get<scene::Sprite>(_state.playerEntity);
+    ctx.assets.manager.ReleaseSprite(sprite);
+  }
+
+  if (_state.particleEntity != UINT32_MAX) {
+    auto &emitter = ctx.registry.Get<scene::ParticleEmitter>(_state.particleEntity);
+    scene::Sprite base{};
+    base.texHandle  = emitter.texHandle;
+    base.matHandle  = emitter.matHandle;
+    base.meshHandle = emitter.meshHandle;
+    ctx.assets.manager.ReleaseSprite(base);
+  }
+
+  ctx.assets.tilemap.Unload("assets/tiles/LevelEntrance.tmx");
   ctx.sceneManager.Unload("level1");
 }
 

--- a/testbed/src/Game.cc
+++ b/testbed/src/Game.cc
@@ -201,7 +201,7 @@ void GameTest::GameImGui(flatearth::Game *gameInstance) {
 
   ImGui::Begin("Debug");
 
-  ImGui::Text("FPS: %.1f", 1.0f / ImGui::GetIO().DeltaTime);
+  ImGui::Text("FPS: %.1f  |  Draw calls: %u", 1.0f / ImGui::GetIO().DeltaTime, ctx.drawCallCount);
 
   if (ImGui::CollapsingHeader("ECS", ImGuiTreeNodeFlags_DefaultOpen)) {
     ImGui::Text("Entities alive: %u", ctx.registry.AliveCount());

--- a/testbed/src/Game.hpp
+++ b/testbed/src/Game.hpp
@@ -23,6 +23,7 @@ public:
   static void GameUnload(flatearth::Game *gameInstance);
   static bool GameUpdate(flatearth::Game *gameInstance, float32 deltaTime);
   static bool GameOnResize(flatearth::Game *gameInstance, uint32 width, uint32 height);
+  static void GameImGui(flatearth::Game *gameInstance);
 
 private:
   static GameState _state;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -15,6 +15,10 @@ fi
 buildDir="./build-${OUT_ROOT}"
 binDir="../${OUT_ROOT}/bin"
 
+if [ -d "$buildDir" ] && [ ! -f "$buildDir/build.ninja" ]; then
+  echo "Stale build directory (wrong generator) — removing..."
+  rm -rf "$buildDir"
+fi
 mkdir -p "$buildDir"
 mkdir -p "$binDir"
 
@@ -24,7 +28,8 @@ RESET='\033[0m'
 
 echo -e "${CYAN}############################### BUILDING TESTS (${type}) ###############################${RESET}"
 
-cmake -DCMAKE_BUILD_TYPE="$type" \
+cmake -G Ninja \
+      -DCMAKE_BUILD_TYPE="$type" \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
       -S . \
       -B "$buildDir"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -31,6 +31,7 @@ echo -e "${CYAN}############################### BUILDING TESTS (${type}) #######
 cmake -G Ninja \
       -DCMAKE_BUILD_TYPE="$type" \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+      -DCMAKE_CXX_SCAN_FOR_MODULES=OFF \
       -S . \
       -B "$buildDir"
 


### PR DESCRIPTION
This pull request adds ImGui integration to the engine, enabling immediate-mode GUI support, and refactors memory management and renderer interfaces. The most significant changes are the addition of ImGui as a dependency, wiring ImGui input and rendering through the engine and Vulkan backend, and several API improvements for memory and renderer management.

**ImGui Integration**

* Added ImGui as a dependency in `engine/CMakeLists.txt` and updated build scripts to include and link ImGui sources. [[1]](diffhunk://#diff-1292c6f7f812b50bda3b43b5a80a670c4c9a86cae1037cc760a75e45a1ae1f1aR59-R69) [[2]](diffhunk://#diff-1292c6f7f812b50bda3b43b5a80a670c4c9a86cae1037cc760a75e45a1ae1f1aR91-R105)
* Integrated ImGui frame lifecycle into the application loop (`Application.cc`), including input wiring from the engine’s input system to ImGui, and calling the game’s `OnImGui` callback if set. [[1]](diffhunk://#diff-06014678d18a220dac3c5e4ccb0d7395acf7ff5ef6f1e2e4f4618bc91a8fc07dR158-R175) [[2]](diffhunk://#diff-8d7039d912d0ae2089cb95e7bacb535d24b4d3630b56eb04cb54feb96420e476R25-R33) [[3]](diffhunk://#diff-7c354219ad6540b6ede0ddf76866d16a9c7535b7bf9ee24dcafbb10a798abbadR105-R114)
* Implemented ImGui initialization, frame management, and rendering in the Vulkan backend, including descriptor pool management and shutdown. [[1]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138R341-R342) [[2]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138R852-R864) [[3]](diffhunk://#diff-b7892af2965717d35178b373008e85837c06dc1e0bf72c4c6e9c7f1179a92138R1069-R1115) [[4]](diffhunk://#diff-f7fd3814618b64b7d6c8dd3a65684dfe47ee4f657df5189c32cf0f7967cd3e3cR58-R61)

**Renderer Interface and Backend Improvements**

* Added ImGui-related virtual methods (`BeginImGuiFrame`, `DrawImGui`, `Flush`) to `IRendererBackend` and implemented them in `VulkanBackend`. [[1]](diffhunk://#diff-cfe671ce89612bd20b400e9359720b4d24df386bf15924257688816880ca5c50R54-R57) [[2]](diffhunk://#diff-f7fd3814618b64b7d6c8dd3a65684dfe47ee4f657df5189c32cf0f7967cd3e3cR58-R61)
* Updated `GameRenderer` and `FrontendRenderer` to expose and call ImGui frame methods, and ensure ImGui draw calls are issued each frame. [[1]](diffhunk://#diff-8cc3e4c645af4b8d2fd5442fcade3f13518dd039a92a13f8ef8aa5eb62ed3000R65-R68) [[2]](diffhunk://#diff-7303ff88819c40b0a7dba571f960eee2ee86ee099f702942b3afb4bef15e0f9fR17-R18) [[3]](diffhunk://#diff-c1832aa357d5f8c0b157ad91003e441db43527affe3524cc35007d94af5e5694R139-R140) [[4]](diffhunk://#diff-c1832aa357d5f8c0b157ad91003e441db43527affe3524cc35007d94af5e5694R234-R237) [[5]](diffhunk://#diff-91822889704061f91d0769ed5370d69eb5ef3c7ddccfd01d29b4816002ac6d0eL46-R70)

**Build System and Script Updates**

* Updated `run.sh` to always use Ninja as the build generator, handle stale build directories, and remove redundant make calls. [[1]](diffhunk://#diff-409c500adbb23b185e09278f68b60b541f09d85e86d8c085b58673d5956351dbR36-L42) [[2]](diffhunk://#diff-409c500adbb23b185e09278f68b60b541f09d85e86d8c085b58673d5956351dbL56-R65) [[3]](diffhunk://#diff-409c500adbb23b185e09278f68b60b541f09d85e86d8c085b58673d5956351dbL74-L78)

**Memory Management Enhancements**

* Renamed `TagToString` to `TagName`, made it public, and added a new `HashMap` tag for improved memory usage reporting. [[1]](diffhunk://#diff-ced72ce51ee549d563d4a2fe68695b900a0050445ce37915f6671d9b8d226bc3L144-R149) [[2]](diffhunk://#diff-ced72ce51ee549d563d4a2fe68695b900a0050445ce37915f6671d9b8d226bc3R190-R191) [[3]](diffhunk://#diff-c4087e0f53c26299e0a9e3adaae637e832baee147b651d5ed6e068de42b03607R88-R95)

**ECS and Input API Additions**

* Added `AliveCount()` to `Registry` for querying the number of alive entities.
* Added methods to `InputManager` for retrieving current and previous mouse positions.