### PR TITLE
Api & General Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ release/*
 .ignore/*
 imgui.ini
 
+.claude/*
+
 # Visual Studio
 .vs/
 *.VC.db

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -170,6 +170,56 @@ install(
 )
 
 ############################################################################
+#   BUILT-IN SHADER EMBEDDING
+
+if(WIN32)
+    set(_glslc_hint "$ENV{VULKAN_SDK}/Bin/glslc.exe")
+else()
+    set(_glslc_hint "$ENV{VULKAN_SDK}/bin/glslc")
+endif()
+
+find_program(GLSLC glslc HINTS "${_glslc_hint}")
+if(NOT GLSLC)
+    message(FATAL_ERROR "glslc not found. Install the Vulkan SDK or add glslc to PATH.")
+endif()
+
+get_filename_component(_repo_root "${CMAKE_CURRENT_SOURCE_DIR}/.." ABSOLUTE)
+set(_shader_src "${_repo_root}/assets/shaders")
+set(_vert_glsl  "${_shader_src}/Builtin.ObjectShader.vert.glsl")
+set(_frag_glsl  "${_shader_src}/Builtin.ObjectShader.frag.glsl")
+set(_vert_spv   "${CMAKE_CURRENT_BINARY_DIR}/Builtin.ObjectShader.vert.spv")
+set(_frag_spv   "${CMAKE_CURRENT_BINARY_DIR}/Builtin.ObjectShader.frag.spv")
+set(_gen_dir    "${CMAKE_CURRENT_BINARY_DIR}/generated")
+set(_shaders_hpp "${_gen_dir}/BuiltinShaders.hpp")
+
+file(MAKE_DIRECTORY "${_gen_dir}")
+
+add_custom_command(
+    OUTPUT "${_vert_spv}" "${_frag_spv}"
+    COMMAND "${GLSLC}" -fshader-stage=vert "${_vert_glsl}" -o "${_vert_spv}"
+    COMMAND "${GLSLC}" -fshader-stage=frag "${_frag_glsl}" -o "${_frag_spv}"
+    DEPENDS "${_vert_glsl}" "${_frag_glsl}"
+    COMMENT "Compiling built-in GLSL shaders to SPIR-V"
+    VERBATIM
+)
+
+add_custom_command(
+    OUTPUT "${_shaders_hpp}"
+    COMMAND ${CMAKE_COMMAND}
+        -DVERT_SPV=${_vert_spv}
+        -DFRAG_SPV=${_frag_spv}
+        -DOUT_FILE=${_shaders_hpp}
+        -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/EmbedShaders.cmake"
+    DEPENDS "${_vert_spv}" "${_frag_spv}"
+    COMMENT "Embedding built-in shaders into BuiltinShaders.hpp"
+    VERBATIM
+)
+
+add_custom_target(flatearth_builtin_shaders DEPENDS "${_shaders_hpp}")
+add_dependencies(${BINARY_NAME} flatearth_builtin_shaders)
+target_include_directories(${BINARY_NAME} PRIVATE "${_gen_dir}")
+
+############################################################################
 #   BUILD OPTIONS
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/engine/cmake/EmbedShaders.cmake
+++ b/engine/cmake/EmbedShaders.cmake
@@ -1,0 +1,33 @@
+# Invoked at build time via cmake -P to convert compiled SPIR-V binaries into
+# an embeddable C++ header.  Called with:
+#   -DVERT_SPV=<path>  -DFRAG_SPV=<path>  -DOUT_FILE=<path>
+
+file(READ "${VERT_SPV}" vert_hex HEX)
+string(REGEX REPLACE "(..)" "0x\\1, " vert_bytes "${vert_hex}")
+string(LENGTH "${vert_hex}" vert_hex_len)
+math(EXPR vert_size "${vert_hex_len} / 2")
+
+file(READ "${FRAG_SPV}" frag_hex HEX)
+string(REGEX REPLACE "(..)" "0x\\1, " frag_bytes "${frag_hex}")
+string(LENGTH "${frag_hex}" frag_hex_len)
+math(EXPR frag_size "${frag_hex_len} / 2")
+
+file(WRITE "${OUT_FILE}"
+"#ifndef _FLATEARTH_RENDERER_VULKAN_BUILTIN_SHADERS_HPP\n"
+"#define _FLATEARTH_RENDERER_VULKAN_BUILTIN_SHADERS_HPP\n"
+"\n"
+"#include <cstddef>\n"
+"#include <cstdint>\n"
+"\n"
+"namespace flatearth::renderer::vulkan::shaders {\n"
+"\n"
+"alignas(4) static constexpr uint8_t kObjectShaderVert[] = { ${vert_bytes} };\n"
+"static constexpr size_t kObjectShaderVertSize = ${vert_size};\n"
+"\n"
+"alignas(4) static constexpr uint8_t kObjectShaderFrag[] = { ${frag_bytes} };\n"
+"static constexpr size_t kObjectShaderFragSize = ${frag_size};\n"
+"\n"
+"} // namespace flatearth::renderer::vulkan::shaders\n"
+"\n"
+"#endif // _FLATEARTH_RENDERER_VULKAN_BUILTIN_SHADERS_HPP\n"
+)

--- a/engine/src/Assets/AssetManager.cc
+++ b/engine/src/Assets/AssetManager.cc
@@ -38,7 +38,7 @@ FeExpect<scene::Sprite, Error> AssetManager::LoadSprite(stringv path,
                                                         resources::MeshShape shape,
                                                         resources::TextureFilter filter) {
   auto loadRes = LoadTexture(string(path), filter);
-  if (!loadRes.has_value()) {
+  if (loadRes.errored()) {
     return FeErr{loadRes.error()};
   }
 
@@ -52,13 +52,13 @@ FeExpect<scene::Sprite, Error> AssetManager::LoadSprite(stringv path,
   }
 
   auto acMatRes = _pRenderer->AcquireMaterial(string(path), pTexture);
-  if (!acMatRes.has_value()) {
+  if (acMatRes.errored()) {
     return FeErr{acMatRes.error()};
   }
   sprite.matHandle = acMatRes.value();
 
   auto acMeshRes = _pRenderer->AcquireMesh(shape);
-  if (!acMeshRes.has_value()) {
+  if (acMeshRes.errored()) {
     return FeErr{acMeshRes.error()};
   }
   sprite.meshHandle = acMeshRes.value();
@@ -77,12 +77,12 @@ FeExpect<scene::Sprite, Error> AssetManager::SpriteFromTexture(resources::Textur
   sprite.texHandle = texHandle;
 
   auto acMatRes = _pRenderer->AcquireMaterial(string(name), pTexture);
-  if (!acMatRes.has_value())
+  if (acMatRes.errored())
     return FeErr{acMatRes.error()};
   sprite.matHandle = acMatRes.value();
 
   auto acMeshRes = _pRenderer->AcquireMesh(shape);
-  if (!acMeshRes.has_value())
+  if (acMeshRes.errored())
     return FeErr{acMeshRes.error()};
   sprite.meshHandle = acMeshRes.value();
 

--- a/engine/src/Assets/PrefabManager.hpp
+++ b/engine/src/Assets/PrefabManager.hpp
@@ -3,7 +3,7 @@
 
 #include "Containers/HashMap.hpp"
 #include "Core/FeMemory.hpp"
-#include "ECS/ComponentPool.hpp"
+#include "ECS/EntityBuilder.hpp"
 #include "ECS/Registry.hpp"
 #include <Scene/Scene.hpp>
 
@@ -11,32 +11,31 @@ namespace flatearth::assets {
 
 class PrefabManager {
 public:
-  using RegisterFn = std::function<void(ecs::EntityId, ecs::Registry &)>;
+  using SetupFn = std::function<void(ecs::EntityBuilder &)>;
 
 public:
   explicit PrefabManager(memory::MemoryManager &);
 
 public:
   template <typename Tag>
-  FEAPI void Register(RegisterFn fn) {
+  FEAPI void Register(SetupFn fn) {
     _prefabsMap.Insert(ecs::PrefabTypeId<Tag>::Value(), std::move(fn));
   }
 
   template <typename Tag>
-  FEAPI FeExpect<ecs::EntityId, Error> Spawn(ecs::Registry &reg, const scene::SceneOwnership &ownership) const {
+  FEAPI FeExpect<ecs::EntityId, Error> Spawn(ecs::Registry &reg, scene::SceneId sceneId) const {
     const auto *pFn = _prefabsMap.Retrieve(ecs::PrefabTypeId<Tag>::Value());
     if (pFn == nullptr) {
       return FeErr{Error("cannot spawn unknown entity prefab", ErrorType::NullptrException)};
     }
 
-    ecs::EntityId id = reg.Create();
-    reg.Insert(id, ownership);
-    (*pFn)(id, reg);
-    return id;
+    ecs::EntityBuilder builder = reg.Spawn();
+    (*pFn)(builder);
+    return builder.OwnedBy(sceneId).Commit();
   }
 
 private:
-  containers::HashMap<uint32, RegisterFn> _prefabsMap;
+  containers::HashMap<uint32, SetupFn> _prefabsMap;
 };
 
 } // namespace flatearth::assets

--- a/engine/src/Assets/TilemapLoader.cc
+++ b/engine/src/Assets/TilemapLoader.cc
@@ -70,9 +70,8 @@ FeExpect<resources::Tilemap, Error> TilemapLoader::Load(stringv tmxPath) {
       (fs::path(tmxPath).parent_path() / tsElem->Attribute("source")).lexically_normal().string();
 
   TilesetLoader tsLoader{_assetManager};
-  auto tsRes = tsLoader.Load(tsxPath);
-  if (!tsRes.has_value()) {
-    FLOG_ERROR("TilemapLoader: failed to load tileset '{}'", tsxPath);
+  auto tsRes = tsLoader.Load(tsxPath).or_error("TilemapLoader: failed to load tileset");
+  if (tsRes.errored()) {
     return FeErr{tsRes.error()};
   }
   tm.tileset = std::move(tsRes.value());

--- a/engine/src/Assets/TilemapManager.cc
+++ b/engine/src/Assets/TilemapManager.cc
@@ -19,10 +19,10 @@ TilemapManager::TilemapManager(memory::MemoryManager &memManager,
                                ecs::Registry &registry)
     : _assetManager(assetManager), _registry(registry), _baseSprites(memManager) {}
 
-FeExpect<ecs::EntityId, Error> TilemapManager::Load(stringv tmxPath, stringv sceneName) {
+FeExpect<ecs::EntityId, Error> TilemapManager::Load(stringv tmxPath, scene::SceneId sceneId) {
   TilemapLoader loader{_assetManager};
   auto tmRes = loader.Load(tmxPath);
-  if (!tmRes.has_value())
+  if (tmRes.errored())
     return FeErr{tmRes.error()};
 
   resources::Tilemap tm = std::move(tmRes.value());
@@ -31,7 +31,7 @@ FeExpect<ecs::EntityId, Error> TilemapManager::Load(stringv tmxPath, stringv sce
   auto baseSpriteRes = _assetManager.SpriteFromTexture(tm.tileset.texture,
                                                        tm.tileset.name,
                                                        resources::MeshShape::Quad);
-  if (!baseSpriteRes.has_value())
+  if (baseSpriteRes.errored())
     return FeErr{baseSpriteRes.error()};
 
   scene::Sprite baseSprite = baseSpriteRes.value();
@@ -64,7 +64,7 @@ FeExpect<ecs::EntityId, Error> TilemapManager::Load(stringv tmxPath, stringv sce
 
         _registry.Insert(e, scene::Transform2D{wx, wy, 0.0f, 1.0f, 1.0f});
         _registry.Insert(e, tileSprite);
-        _registry.Insert(e, scene::SceneOwnership{sceneName});
+        _registry.Insert(e, scene::SceneOwnership{sceneId});
       }
     }
   }
@@ -82,7 +82,7 @@ FeExpect<ecs::EntityId, Error> TilemapManager::Load(stringv tmxPath, stringv sce
       _registry.Insert(e, scene::Transform2D{wx, wy});
       _registry.Insert(e, physics::RigidBody{.type = physics::BodyType::Static});
       _registry.Insert(e, physics::BoxCollider{.halfWidth = 0.5f, .halfHeight = 0.5f});
-      _registry.Insert(e, scene::SceneOwnership{sceneName});
+      _registry.Insert(e, scene::SceneOwnership{sceneId});
     }
   }
 
@@ -94,7 +94,7 @@ FeExpect<ecs::EntityId, Error> TilemapManager::Load(stringv tmxPath, stringv sce
 
   auto root = _registry.Create();
   _registry.Insert(root, scene::Transform2D{});
-  _registry.Insert(root, scene::SceneOwnership{sceneName});
+  _registry.Insert(root, scene::SceneOwnership{sceneId});
 
   FLOG_INFO("TilemapManager: loaded '{}' — {} render layers, {} collision tiles, {} objects",
             tmxPath, renderLayerCount, collTileCount, objectCount);

--- a/engine/src/Assets/TilemapManager.hpp
+++ b/engine/src/Assets/TilemapManager.hpp
@@ -7,6 +7,7 @@
 #include "Error.hpp"
 #include "ECS/ECSTypes.hpp"
 #include "Scene/Components/Sprite.hpp"
+#include "Scene/Scene.hpp"
 
 namespace flatearth::ecs { class Registry; }
 
@@ -20,7 +21,7 @@ public:
                           AssetManager &assetManager,
                           ecs::Registry &registry);
 
-  FEAPI FeExpect<ecs::EntityId, Error> Load(stringv tmxPath, stringv sceneName);
+  FEAPI FeExpect<ecs::EntityId, Error> Load(stringv tmxPath, scene::SceneId sceneId);
   FEAPI void Unload(stringv tmxPath);
 
 private:

--- a/engine/src/Assets/TilesetLoader.cc
+++ b/engine/src/Assets/TilesetLoader.cc
@@ -33,8 +33,8 @@ FeExpect<Tileset, Error> TilesetLoader::Load(stringv tsxPath) {
 
   namespace stdfs = std::filesystem;
   const string cImagePath = (stdfs::path(tsxPath).parent_path() / imageElem->Attribute("source")).string();
-  auto texRes = _assetManager.LoadTexture(cImagePath);
-  if (!texRes.has_value()) {
+  auto texRes = _assetManager.LoadTexture(cImagePath).or_error("TilesetLoader: failed to load texture");
+  if (texRes.errored()) {
     return FeErr{texRes.error()};
   }
 

--- a/engine/src/Core/Application.cc
+++ b/engine/src/Core/Application.cc
@@ -2,21 +2,18 @@
 
 #include "Core/Logger.hpp"
 #include "Defines.hpp"
-#include "Error.hpp"
 
 namespace flatearth {
 
-Application::Application() : _engine(_memoryManager) {}
+Application::Application() : _engine(_memoryManager) {
+}
 
 FeExpect<void, Error> Application::Initialize(Game &game, const ApplicationConfig &config) {
-  if (_initialized) return {};
+  if (_initialized)
+    return {};
   FILE_LOGGING(FeTrue);
   _appConfig = config;
-  auto res = _engine.Initialize(game, _appConfig);
-  if (!res.has_value()) {
-    FLOG_FATAL("engine failed to initialize");
-    return FeErr{res.error()};
-  }
+  FE_RIPPLE(_engine.Initialize(game, _appConfig).or_error("engine failed to initialize"));
   _initialized = true;
   return {};
 }

--- a/engine/src/Core/Engine.cc
+++ b/engine/src/Core/Engine.cc
@@ -64,61 +64,43 @@ FeExpect<void, Error> Engine::Initialize(Game &game, ApplicationConfig &config) 
                                                                  _coreModule.Input(),
                                                                  _eventManager);
 
-  auto platInitRes = _pPlatform->Initialize();
-  if (!platInitRes.has_value()) {
-    FLOG_ERROR("engine failed to initialize platform");
-    return FeErr{platInitRes.error()};
-  }
-  _state.platformState = _pPlatform->State();
-
-  auto listenerRes = _engineListener->Initialize();
-  if (!listenerRes.has_value()) {
-    FLOG_ERROR("engine listener failed to initialize");
-    return FeErr{listenerRes.error()};
-  }
-
-  auto renderInitRes = _renderer.Initialize();
-  if (!renderInitRes.has_value()) {
-    FLOG_ERROR("renderer failed to initialize: {}", renderInitRes.error().message);
-    return FeErr{renderInitRes.error()};
-  }
-
-  auto coreInit = _coreModule.Initialize();
-  if (!coreInit.has_value()) {
-    FLOG_ERROR("core module failed to initialize");
-    return FeErr{coreInit.error()};
-  }
-
-  auto assetInit = _assetsModule.Initialize(&_renderer.FrontendReference());
-  if (!assetInit.has_value()) {
-    FLOG_ERROR("assets module failed to initialize");
-    return FeErr{assetInit.error()};
-  }
-
-  auto projectInit = _gameModule.Initialize();
-  if (!projectInit.has_value()) {
-    FLOG_ERROR("project module failed to initialize");
-    return FeErr{projectInit.error()};
-  }
-
-  _state.isRunning = FeTrue;
-  _state.isSuspended = FeFalse;
-  _state.platformState = _pPlatform->State();
-
-  if (_state.pGameInstance->Load != nullptr && !_state.pGameInstance->Load(_state.pGameInstance)) {
-    FLOG_FATAL("game failed to load resources");
-    return FeErr{Error("game Load() failed", ErrorType::GameInitializeError)};
-  }
-
-  auto registerRes = RegisterSystems();
-  if (!registerRes.has_value()) {
-    FLOG_ERROR("failed to register engine systems");
-    return FeErr{registerRes.error()};
-  }
-  _scheduler.BootSystems(_registry);
-
-  FLOG_INFO("engine successfully initialized");
-  return {};
+  return _pPlatform->Initialize()
+      .or_error("engine failed to initialize platform")
+      .and_then([&]() -> FeExpect<void, Error> {
+        _state.platformState = _pPlatform->State();
+        return _engineListener->Initialize().or_error("engine listener failed to initialize");
+      })
+      .and_then([&]() -> FeExpect<void, Error> {
+        return _renderer.Initialize().or_error("renderer failed to initialize");
+      })
+      .and_then([&]() -> FeExpect<void, Error> {
+        return _coreModule.Initialize().or_error("core module failed to initialize");
+      })
+      .and_then([&]() -> FeExpect<void, Error> {
+        return _assetsModule.Initialize(&_renderer.FrontendReference()).or_error("assets module failed to initialize");
+      })
+      .and_then([&]() -> FeExpect<void, Error> {
+        return _gameModule.Initialize().or_error("project module failed to initialize");
+      })
+      .and_then([&]() -> FeExpect<void, Error> {
+        _state.isRunning = FeTrue;
+        _state.isSuspended = FeFalse;
+        _state.platformState = _pPlatform->State();
+        if (_state.pGameInstance->Load != nullptr &&
+            !_state.pGameInstance->Load(_state.pGameInstance)) {
+          FLOG_FATAL("game failed to load resources");
+          return FeErr{Error("game Load() failed", ErrorType::GameInitializeError)};
+        }
+        return {};
+      })
+      .and_then([&]() -> FeExpect<void, Error> {
+        return RegisterSystems().or_error("failed to register engine systems");
+      })
+      .and_then([&]() -> FeExpect<void, Error> {
+        _scheduler.BootSystems(_registry);
+        FLOG_INFO("engine successfully initialized");
+        return {};
+      });
 }
 
 FeExpect<void, Error> Engine::Start() {
@@ -131,7 +113,7 @@ FeExpect<void, Error> Engine::Start() {
 
   while (_state.isRunning) {
     auto pollRes = _pPlatform->PollEvents();
-    if (!pollRes.has_value()) {
+    if (pollRes.errored()) {
       FLOG_ERROR("engine failed to poll events: {}", pollRes.error().message);
       return FeErr{pollRes.error()};
     }
@@ -176,7 +158,7 @@ FeExpect<void, Error> Engine::Start() {
     ImGui::Render();
 
     auto drawRes = _renderer.Draw(deltaTime);
-    if (!drawRes.has_value()) {
+    if (drawRes.errored()) {
       FLOG_ERROR("renderer failed to draw frame: {}", drawRes.error().message);
       return FeErr{drawRes.error()};
     }
@@ -208,32 +190,32 @@ FeExpect<void, Error> Engine::RegisterSystems() {
   _scheduler.Prune();
 
   auto transformRes = _scheduler.Register<systems::TransformSystem>(_memoryManager);
-  if (!transformRes.has_value()) {
+  if (transformRes.errored()) {
     FLOG_ERROR("could not register TransformSystem");
     return FeErr{transformRes.error()};
   }
 
   auto spriteRes = _scheduler.Register<systems::SpriteSystem>();
-  if (!spriteRes.has_value()) {
+  if (spriteRes.errored()) {
     FLOG_ERROR("could not register SpriteSystem");
     return FeErr{spriteRes.error()};
   }
 
   auto physicsRes = _scheduler.Register<physics::PhysicsSystem>(_gameModule.World());
-  if (!physicsRes.has_value()) {
+  if (physicsRes.errored()) {
     FLOG_ERROR("could not register PhysicsSystem");
     return FeErr{physicsRes.error()};
   }
   physicsRes.value().Before<systems::TransformSystem>();
 
   auto particleRes = _scheduler.Register<systems::ParticleSystem>();
-  if (!particleRes.has_value()) {
+  if (particleRes.errored()) {
     FLOG_ERROR("could not register ParticleSystem");
     return FeErr{particleRes.error()};
   }
 
   auto audioRes = _scheduler.Register<systems::AudioSystem>(_coreModule.Audio());
-  if (!audioRes.has_value()) {
+  if (audioRes.errored()) {
     FLOG_ERROR("could not register AudioSystem");
     return FeErr{audioRes.error()};
   }
@@ -243,7 +225,7 @@ FeExpect<void, Error> Engine::RegisterSystems() {
   }
 
   auto buildRes = _scheduler.Build();
-  if (!buildRes.has_value()) {
+  if (buildRes.errored()) {
     FLOG_ERROR("failed to build scheduler");
     return FeErr{buildRes.error()};
   }

--- a/engine/src/Core/Engine.cc
+++ b/engine/src/Core/Engine.cc
@@ -64,57 +64,68 @@ FeExpect<void, Error> Engine::Initialize(Game &game, ApplicationConfig &config) 
                                                                  _coreModule.Input(),
                                                                  _eventManager);
 
-  return _pPlatform->Initialize()
-      .or_error("engine failed to initialize platform")
-      .and_then([&]() -> FeExpect<void, Error> {
-        _state.platformState = _pPlatform->State();
-        return _engineListener->Initialize().or_error("engine listener failed to initialize");
-      })
-      .and_then([&]() -> FeExpect<void, Error> {
-        return _renderer.Initialize().or_error("renderer failed to initialize");
-      })
-      .and_then([&]() -> FeExpect<void, Error> {
-        return _coreModule.Initialize().or_error("core module failed to initialize");
-      })
-      .and_then([&]() -> FeExpect<void, Error> {
-        return _assetsModule.Initialize(&_renderer.FrontendReference()).or_error("assets module failed to initialize");
-      })
-      .and_then([&]() -> FeExpect<void, Error> {
-        return _gameModule.Initialize().or_error("project module failed to initialize");
-      })
-      .and_then([&]() -> FeExpect<void, Error> {
-        _state.isRunning = FeTrue;
-        _state.isSuspended = FeFalse;
-        _state.platformState = _pPlatform->State();
-        if (_state.pGameInstance->Load != nullptr &&
-            !_state.pGameInstance->Load(_state.pGameInstance)) {
-          FLOG_FATAL("game failed to load resources");
-          return FeErr{Error("game Load() failed", ErrorType::GameInitializeError)};
-        }
-        return {};
-      })
-      .and_then([&]() -> FeExpect<void, Error> {
-        return RegisterSystems().or_error("failed to register engine systems");
-      })
-      .and_then([&]() -> FeExpect<void, Error> {
-        _scheduler.BootSystems(_registry);
-        FLOG_INFO("engine successfully initialized");
-        return {};
-      });
+  auto platInitRes = _pPlatform->Initialize().or_error("failed to initialize OS platform");
+  if (platInitRes.errored()) {
+    return FeErr{platInitRes.error()};
+  }
+  _state.platformState = _pPlatform->State();
+
+  auto listenerRes =
+      _engineListener->Initialize().or_error("failed to initialize engine event listener");
+  if (listenerRes.errored()) {
+    return FeErr{listenerRes.error()};
+  }
+
+  auto rendererInit = _renderer.Initialize().or_error("failed to initialize game renderer");
+  if (rendererInit.errored()) {
+    return FeErr{rendererInit.error()};
+  }
+
+  auto coreInit = _coreModule.Initialize().or_error("failed to initialize core module");
+  if (coreInit.errored()) {
+    return FeErr{coreInit.error()};
+  }
+
+  auto assetsInit = _assetsModule.Initialize(&_renderer.FrontendReference())
+                        .or_error("failed to initialize assets module");
+  if (assetsInit.errored()) {
+    return FeErr{assetsInit.error()};
+  }
+
+  auto gameInit = _gameModule.Initialize().or_error("failed to initialize game project module");
+  if (gameInit.errored()) {
+    return FeErr{gameInit.error()};
+  }
+
+  _state.isRunning = FeTrue;
+  _state.isSuspended = FeFalse;
+  if (_state.pGameInstance->Load != nullptr && !_state.pGameInstance->Load(_state.pGameInstance)) {
+    FLOG_FATAL("game failed to load resources");
+    return FeErr{Error("game Load() failed", ErrorType::GameInitializeError)};
+  }
+
+  auto systemRes = RegisterSystems().or_error("failed to register engine systems");
+  if (systemRes.errored()) {
+    return FeErr{systemRes.error()};
+  }
+  _scheduler.BootSystems(_registry);
+
+  FLOG_INFO("engine successfully initialized");
+  return {};
 }
 
 FeExpect<void, Error> Engine::Start() {
   _state.clock.Start();
   _state.clock.Update();
   _state.lastTime = _state.clock.Elapsed();
+
   float64 runningTime = 0.0;
   uint8 frameCount = 0;
   float64 targetFrameSeconds = 1.0 / 60;
 
   while (_state.isRunning) {
-    auto pollRes = _pPlatform->PollEvents();
+    auto pollRes = _pPlatform->PollEvents().or_error("engine failed to poll events");
     if (pollRes.errored()) {
-      FLOG_ERROR("engine failed to poll events: {}", pollRes.error().message);
       return FeErr{pollRes.error()};
     }
     if (!pollRes.value()) {
@@ -157,9 +168,8 @@ FeExpect<void, Error> Engine::Start() {
     _devConsole.Draw(_coreModule.KVarsRegistry());
     ImGui::Render();
 
-    auto drawRes = _renderer.Draw(deltaTime);
+    auto drawRes = _renderer.Draw(deltaTime).or_error("renderer failed to draw frame");
     if (drawRes.errored()) {
-      FLOG_ERROR("renderer failed to draw frame: {}", drawRes.error().message);
       return FeErr{drawRes.error()};
     }
     _ctx.drawCallCount = _renderer.LastDrawCallCount();

--- a/engine/src/Core/EngineConsole.cc
+++ b/engine/src/Core/EngineConsole.cc
@@ -100,7 +100,7 @@ void DevConsole::DispatchCommand(ConsoleCmd cmd, stringv name, stringv value, KV
         return;
       }
       auto res = kvars.ParseAndSet(name, value);
-      if (!res.has_value()) {
+      if (res.errored()) {
         _history.push_back("  error: " + res.error().message);
       } else {
         _history.push_back("  " + string(name) + " = " + kvars.GetAsString(name));

--- a/engine/src/Core/EngineListener.cc
+++ b/engine/src/Core/EngineListener.cc
@@ -251,14 +251,7 @@ FeExpect<bool, Error> EngineListener::OnButtonRelease(const event::EventDispatch
   using event::Uint16x8;
 
   Uint16x8 buttonContext = eventCtx.Get<Uint16x8>();
-  auto button = static_cast<input::Button>(buttonContext[0]);
-  if (button == input::Button::Left) {
-    FLOG_DEBUG("mouse left click released");
-  } else if (button == input::Button::Middle) {
-    FLOG_DEBUG("mouse wheel released");
-  } else {
-    FLOG_DEBUG("mouse right click released");
-  }
+  // NOTE to cast mouse click: auto button = static_cast<input::Button>(buttonContext[0]);
 
   return FeTrue;
 }

--- a/engine/src/Core/EngineListener.cc
+++ b/engine/src/Core/EngineListener.cc
@@ -1,12 +1,15 @@
 #include "EngineListener.hpp"
 
 #include "Core/Logger.hpp"
-#include "GameTypes.hpp"
 #include "Renderer/GameRenderer.hpp"
+#include "GameTypes.hpp"
 
 namespace flatearth {
 
+constexpr stringv cUngracefulShutdown = "engine did not shutdown gracefully";
+
 const char *KeyToString(input::Keys key);
+constexpr string RegisterFailedMessageFor(stringv system);
 
 EngineListener::EngineListener(event::EventManager &eventManager,
                                renderer::GameRenderer &renderer,
@@ -21,49 +24,38 @@ EngineListener::~EngineListener() {
   }
 
   using event::SystemEventCode;
-  auto appQuitUnregisterRes = _eventManager.UnregisterEvent(SystemEventCode::ApplicationQuit, this);
-  if (!appQuitUnregisterRes.has_value() || !appQuitUnregisterRes.value()) {
-    FLOG_ERROR("engine did not shutdown gracefully");
+  auto appQuitUnregisterRes = _eventManager.UnregisterEvent(SystemEventCode::ApplicationQuit, this)
+      .or_error(cUngracefulShutdown);
+  if (appQuitUnregisterRes.errored() || !appQuitUnregisterRes.value()) {
     return;
   }
 
-  auto keyPressUnregisterRes = _eventManager.UnregisterEvent(SystemEventCode::KeyPressed, this);
-  if (!keyPressUnregisterRes.has_value() || !keyPressUnregisterRes.value()) {
-    FLOG_ERROR("engine did not shutdown gracefully");
+  auto keyPressUnregisterRes = _eventManager.UnregisterEvent(SystemEventCode::KeyPressed, this)
+      .or_error(cUngracefulShutdown);
+  if (keyPressUnregisterRes.errored() || !keyPressUnregisterRes.value()) {
     return;
   }
 
-  auto keyReleaseUnregisterRes = _eventManager.UnregisterEvent(SystemEventCode::KeyReleased, this);
-  if (!keyReleaseUnregisterRes.has_value() || !keyReleaseUnregisterRes.value()) {
-    FLOG_ERROR("engine did not shutdown gracefully");
+  auto keyReleaseUnregisterRes = _eventManager.UnregisterEvent(SystemEventCode::KeyReleased, this)
+      .or_error(cUngracefulShutdown);
+  if (keyReleaseUnregisterRes.errored() || !keyReleaseUnregisterRes.value()) {
     return;
   }
 
-  auto resizeUnregisterRes = _eventManager.UnregisterEvent(SystemEventCode::WindowResized, this);
-  if (!resizeUnregisterRes.has_value() || !resizeUnregisterRes.value()) {
-    FLOG_ERROR("engine did not shutdown gracefully");
+  auto resizeUnregisterRes = _eventManager.UnregisterEvent(SystemEventCode::WindowResized, this)
+      .or_error(cUngracefulShutdown);
+  if (resizeUnregisterRes.errored() || !resizeUnregisterRes.value()) {
     return;
   }
 
-  auto buttonPressUnregisterRes =
-      _eventManager.UnregisterEvent(SystemEventCode::ButtonPressed, this);
-  if (!buttonPressUnregisterRes.has_value()) {
-    FLOG_ERROR("engine did not shutdown gracefully");
-    return;
-  }
+  _eventManager.UnregisterEvent(SystemEventCode::ButtonPressed, this)
+      .or_log_error(cUngracefulShutdown);
 
-  auto buttonReleaseUnregisterRes =
-      _eventManager.UnregisterEvent(SystemEventCode::ButtonReleased, this);
-  if (!buttonReleaseUnregisterRes.has_value()) {
-    FLOG_ERROR("engine did not shutdhow gracefully");
-    return;
-  }
+  _eventManager.UnregisterEvent(SystemEventCode::ButtonReleased, this)
+      .or_log_error(cUngracefulShutdown);
 
-  auto mouseMoveUnregisterRes = _eventManager.UnregisterEvent(SystemEventCode::MouseMoved, this);
-  if (!mouseMoveUnregisterRes.has_value()) {
-    FLOG_ERROR("engine did not shutdown gracefully");
-    return;
-  }
+  _eventManager.UnregisterEvent(SystemEventCode::MouseMoved, this)
+      .or_log_error(cUngracefulShutdown);
 
   _allInitialized = FeFalse;
   FLOG_INFO("engine listener successfully shutdown");
@@ -109,7 +101,7 @@ FeExpect<bool, Error> EngineListener::OnResize(const event::EventDispatchContext
   }
 
   auto res = _renderer.FrontendReference().OnResize(width, height);
-  if (!res.has_value()) {
+  if (res.errored()) {
     FLOG_ERROR("renderer failed to resize to {}x{}", width, height);
     return FeFalse;
   }
@@ -168,46 +160,45 @@ FeExpect<bool, Error> EngineListener::OnMouseMove(const event::EventDispatchCont
 FeExpect<void, Error> EngineListener::WireEvents() {
   using event::SystemEventCode;
 
-  auto resizeRegisterRes = _eventManager.RegisterEvent(SystemEventCode::WindowResized, this);
-  if (!resizeRegisterRes.has_value()) {
-    FLOG_ERROR("failed to register resize event");
+  auto resizeRegisterRes = _eventManager.RegisterEvent(SystemEventCode::WindowResized, this)
+      .or_error("failed to register resize event");
+  if (resizeRegisterRes.errored()) {
     return FeErr{resizeRegisterRes.error()};
   }
 
-  auto keyPressRegisterRes = _eventManager.RegisterEvent(SystemEventCode::KeyPressed, this);
-  if (!keyPressRegisterRes.has_value()) {
-    FLOG_ERROR("failed to register key press event");
+  auto keyPressRegisterRes = _eventManager.RegisterEvent(SystemEventCode::KeyPressed, this)
+      .or_error("failed to register key press event");
+  if (keyPressRegisterRes.errored()) {
     return FeErr{keyPressRegisterRes.error()};
   }
 
-  auto keyReleasedRegisterRes = _eventManager.RegisterEvent(SystemEventCode::KeyReleased, this);
-  if (!keyReleasedRegisterRes.has_value()) {
-    FLOG_ERROR("failed to register key release event");
+  auto keyReleasedRegisterRes = _eventManager.RegisterEvent(SystemEventCode::KeyReleased, this)
+      .or_error("failed to register key release event");
+  if (keyReleasedRegisterRes.errored()) {
     return FeErr{keyReleasedRegisterRes.error()};
   }
 
-  auto appQuitRegisterRes = _eventManager.RegisterEvent(SystemEventCode::ApplicationQuit, this);
-  if (!appQuitRegisterRes.has_value()) {
-    FLOG_ERROR("failed to register application quit event");
+  auto appQuitRegisterRes = _eventManager.RegisterEvent(SystemEventCode::ApplicationQuit, this)
+      .or_error("failed to register application quit event");
+  if (appQuitRegisterRes.errored()) {
     return FeErr{appQuitRegisterRes.error()};
   }
 
-  auto buttonPressRegisterRes = _eventManager.RegisterEvent(SystemEventCode::ButtonPressed, this);
-  if (!buttonPressRegisterRes.has_value()) {
-    FLOG_ERROR("failed to register mouse button press event");
+  auto buttonPressRegisterRes = _eventManager.RegisterEvent(SystemEventCode::ButtonPressed, this)
+      .or_error("failed to register mouse button press event");
+  if (buttonPressRegisterRes.errored()) {
     return FeErr{buttonPressRegisterRes.error()};
   }
 
-  auto buttonReleaseRegisterRes =
-      _eventManager.RegisterEvent(SystemEventCode::ButtonReleased, this);
-  if (!buttonReleaseRegisterRes.has_value()) {
-    FLOG_ERROR("failed to register mouse button release event");
+  auto buttonReleaseRegisterRes = _eventManager.RegisterEvent(SystemEventCode::ButtonReleased, this)
+      .or_error("failed to register mouse button release event");
+  if (buttonReleaseRegisterRes.errored()) {
     return FeErr{buttonReleaseRegisterRes.error()};
   }
 
-  auto mouseMoveRegisterRes = _eventManager.RegisterEvent(SystemEventCode::MouseMoved, this);
-  if (!mouseMoveRegisterRes.has_value()) {
-    FLOG_ERROR("failed to register mouse move event");
+  auto mouseMoveRegisterRes = _eventManager.RegisterEvent(SystemEventCode::MouseMoved, this)
+      .or_error("failed to register mouse move event");
+  if (mouseMoveRegisterRes.errored()) {
     return FeErr{mouseMoveRegisterRes.error()};
   }
 
@@ -226,12 +217,6 @@ FeExpect<bool, Error> EngineListener::OnKeyPress(const event::EventDispatchConte
     return _eventManager.FireEvent(SystemEventCode::ApplicationQuit, this, eventCtx);
   }
 
-  if (keyCode == input::Keys::KEY_A) {
-    FLOG_DEBUG("Explicit - A pressed");
-  } else {
-    FLOG_DEBUG("{} key pressed in window", KeyToString(keyCode));
-  }
-
   return FeTrue;
 }
 
@@ -246,12 +231,6 @@ FeExpect<bool, Error> EngineListener::OnKeyRelease(const event::EventDispatchCon
     return _eventManager.FireEvent(SystemEventCode::ApplicationQuit, this, eventCtx);
   }
 
-  if (keyCode == input::Keys::KEY_A) {
-    FLOG_DEBUG("Explicit - A released");
-  } else {
-    FLOG_DEBUG("{} key released in window", KeyToString(keyCode));
-  }
-
   return FeTrue;
 }
 
@@ -261,14 +240,7 @@ FeExpect<bool, Error> EngineListener::OnButtonPress(const event::EventDispatchCo
   using event::Uint16x8;
 
   Uint16x8 buttonContext = eventCtx.Get<Uint16x8>();
-  auto button = static_cast<input::Button>(buttonContext[0]);
-  if (button == input::Button::Left) {
-    FLOG_DEBUG("mouse left click pressed");
-  } else if (button == input::Button::Middle) {
-    FLOG_DEBUG("mouse wheel pressed");
-  } else {
-    FLOG_DEBUG("mouse right click pressed");
-  }
+  // NOTE to get button: auto button = static_cast<input::Button>(buttonContext[0]);
 
   return FeTrue;
 }
@@ -550,6 +522,10 @@ const char *KeyToString(input::Keys key) {
     default:
       return "Unknown Key";
   }
+}
+
+constexpr string RegisterFailedMessageFor(stringv system) {
+  return "failed to register " + string(system) + " event";
 }
 
 } // namespace flatearth

--- a/engine/src/Core/Event.cc
+++ b/engine/src/Core/Event.cc
@@ -72,7 +72,7 @@ FeExpect<bool, Error> EventManager::UnregisterEvent(SystemEventCode code,
     }
 
     auto result = events.PopAt(i);
-    if (!result.has_value()) {
+    if (result.errored()) {
       FLOG_ERROR("failed to pop event from DArray at index {}", i);
       return FeErr{result.error()};
     }
@@ -102,7 +102,7 @@ EventManager::FireEvent(SystemEventCode code, void *sender, const EventContext &
 
     FeExpect<bool, Error> res = DecideAndDispatch(code, event.listener, dispatchCtx, eventCtx);
 
-    if (!res.has_value()) {
+    if (res.errored()) {
       return FeErr{res.error()};
     }
 
@@ -137,7 +137,7 @@ EventManager::Broadcast(SystemEventCode code, void *sender, const EventContext &
 
     FeExpect<bool, Error> res = DecideAndDispatch(code, event.listener, dispatchCtx, eventCtx);
 
-    if (!res.has_value()) {
+    if (res.errored()) {
       FLOG_ERROR("callback for event {} return error: {}", event.id, res.error().message);
       errCount++;
       continue;

--- a/engine/src/Core/FeLog.cc
+++ b/engine/src/Core/FeLog.cc
@@ -1,0 +1,25 @@
+#include "Defines.hpp"
+#include "Core/Logger.hpp"
+
+#include <cstdlib>
+
+namespace flatearth::detail {
+
+[[noreturn]] void FatalLog(stringv userMsg, stringv errMsg) {
+  FLOG_FATAL("{}: {}", userMsg, errMsg);
+  std::exit(1);
+}
+
+void ErrorLog(stringv userMsg, stringv errMsg) {
+  FLOG_ERROR("{}: {}", userMsg, errMsg);
+}
+
+void WarnLog(stringv userMsg, stringv errMsg) {
+  if (errMsg.empty()) {
+    FLOG_WARN("{}", userMsg);
+  } else {
+    FLOG_WARN("{}: {}", userMsg, errMsg);
+  }
+}
+
+} // namespace flatearth::detail

--- a/engine/src/Core/FeLog.cc
+++ b/engine/src/Core/FeLog.cc
@@ -10,15 +10,18 @@ namespace flatearth::detail {
   std::exit(1);
 }
 
-void ErrorLog(stringv userMsg, stringv errMsg) {
-  FLOG_ERROR("{}: {}", userMsg, errMsg);
+void ErrorLog(stringv userMsg, stringv errMsg, std::source_location loc) {
+  febundle::core::Logger::Self().Log(
+      febundle::core::LogLevel::Error, loc, "{}: {}", userMsg, errMsg);
 }
 
-void WarnLog(stringv userMsg, stringv errMsg) {
+void WarnLog(stringv userMsg, stringv errMsg, std::source_location loc) {
   if (errMsg.empty()) {
-    FLOG_WARN("{}", userMsg);
+    febundle::core::Logger::Self().Log(
+        febundle::core::LogLevel::Warn, loc, "{}", userMsg);
   } else {
-    FLOG_WARN("{}: {}", userMsg, errMsg);
+    febundle::core::Logger::Self().Log(
+        febundle::core::LogLevel::Warn, loc, "{}: {}", userMsg, errMsg);
   }
 }
 

--- a/engine/src/Core/KVarRegistry.cc
+++ b/engine/src/Core/KVarRegistry.cc
@@ -26,7 +26,7 @@ FeExpect<void, Error> KVarRegistry::Register(stringv name, stringv desc, KVarVal
   kvar.defaultValue = defaultVal;
 
   auto insertRes = _localMap.Insert(key, kvar);
-  if (!insertRes.has_value()) {
+  if (insertRes.errored()) {
     FLOG_ERROR("inserting new kvar failed");
     return FeErr{insertRes.error()};
   }
@@ -50,7 +50,7 @@ FeExpect<bool, Error> KVarRegistry::ParseAndSet(stringv name, stringv strValue) 
   const KVarValue oldValue = pKvar->value;
 
   auto parseRes = ParseKVarValue(strValue, *pKvar);
-  if (!parseRes.has_value()) {
+  if (parseRes.errored()) {
     return FeErr{parseRes.error()};
   }
 

--- a/engine/src/Core/KVarRegistry.hpp
+++ b/engine/src/Core/KVarRegistry.hpp
@@ -4,7 +4,6 @@
 #include "Containers/HashMap.hpp"
 #include "Core/FeMemory.hpp"
 #include "Defines.hpp"
-#include "Error.hpp"
 
 #include <variant>
 

--- a/engine/src/Core/Logger.hpp
+++ b/engine/src/Core/Logger.hpp
@@ -40,6 +40,7 @@ struct LogMessage {
   LogLevel level;
   std::source_location where;
   string message;
+  bool toConsole;
   bool toFile;
 };
 
@@ -84,13 +85,13 @@ public:
       return;
     }
 
-    const bool logToFile = true;
     const string out = format(level, where, fmt, args...);
     LogMessage msg{
         .level = level,
         .where = where,
         .message = out,
-        .toFile = logToFile,
+        .toConsole = true,
+        .toFile = true,
     };
 
     std::lock_guard lock(_qMutex);
@@ -106,13 +107,13 @@ public:
       return;
     }
 
-    const bool logToFile = false;
     const string out = format(level, where, fmt, args...);
     LogMessage msg{
         .level = level,
         .where = where,
         .message = out,
-        .toFile = logToFile,
+        .toConsole = true,
+        .toFile = false,
     };
 
     std::lock_guard lock(_qMutex);
@@ -131,12 +132,12 @@ private:
           _logQ.pop();
           lock.unlock();
 
-          if (msg.toFile && _logToFile && _logFile.is_open()) {
-            _logFile << msg.message;
+          if (msg.toConsole) {
+            std::print("{}", msg.message);
           }
 
-          if (!msg.toFile) {
-            std::print("{}", msg.message);
+          if (msg.toFile && _logToFile && _logFile.is_open()) {
+            _logFile << msg.message;
           }
 
           lock.lock();
@@ -155,10 +156,12 @@ private:
     while (!_logQ.empty()) {
       auto msg = _logQ.front();
       _logQ.pop();
+      if (msg.toConsole) {
+        std::print("{}", msg.message);
+      }
+
       if (msg.toFile && _logToFile && _logFile.is_open()) {
         _logFile << msg.message;
-      } else {
-        std::print("{}", msg.message);
       }
     }
 

--- a/engine/src/Core/Logger.hpp
+++ b/engine/src/Core/Logger.hpp
@@ -280,6 +280,10 @@ private:
 
 #if FLATEARTH_LOGGING_ENABLED
 
+#define FLOG_SRC_FATAL(fmt, src, ...) \
+  febundle::core::Logger::Self().Log( \
+    febundle::core::LogLevel::Fatal, src, fmt, ##__VA_ARGS__)
+
 #define LOG_TRACE(fmt, ...)           \
   febundle::core::Logger::Self().Log( \
       febundle::core::LogLevel::Trace, std::source_location::current(), fmt, ##__VA_ARGS__)

--- a/engine/src/Defines.hpp
+++ b/engine/src/Defines.hpp
@@ -9,6 +9,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <source_location>
 #include <sstream>
 #include <string>
 
@@ -62,9 +63,19 @@ STATIC_ASSERT(sizeof(float64) == 8, "Expected float64 to be 8 bytes");
 
 namespace flatearth::detail {
 [[noreturn]] void FatalLog(stringv userMsg, stringv errMsg);
-void ErrorLog(stringv userMsg, stringv errMsg);
-void WarnLog(stringv userMsg, stringv errMsg = "");
+void ErrorLog(stringv userMsg, stringv errMsg, std::source_location loc);
+void WarnLog(stringv userMsg, stringv errMsg, std::source_location loc);
 } // namespace flatearth::detail
+
+template <typename... Args>
+struct FmtWithLoc {
+  stringv fmt;
+  std::source_location loc;
+  constexpr FmtWithLoc(const char *f, std::source_location l = std::source_location::current())
+      : fmt(f), loc(l) {}
+  constexpr FmtWithLoc(stringv f, std::source_location l = std::source_location::current())
+      : fmt(f), loc(l) {}
+};
 
 // Platform detection
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__)
@@ -155,7 +166,7 @@ struct FeExpect : std::expected<Ret, Err> {
   using Base = std::expected<Ret, Err>;
   using Base::Base;
 
-  auto or_fatal(stringv msg)
+  auto or_fatal(stringv msg, std::source_location src = std::source_location::current())
     requires requires(Err e) { e.message; }
   {
     if (!this->has_value()) {
@@ -167,35 +178,39 @@ struct FeExpect : std::expected<Ret, Err> {
   }
 
   template <typename... Args>
-  [[nodiscard]] FeExpect or_error(std::format_string<Args...> fmt, Args &&...args)
+  [[nodiscard]] FeExpect or_error(FmtWithLoc<std::type_identity_t<Args>...> fmtloc, Args &&...args)
     requires requires(Err e) { e.message; }
   {
     if (!this->has_value()) {
-      flatearth::detail::ErrorLog(std::format(fmt, std::forward<Args>(args)...),
-                                  this->error().message);
+      flatearth::detail::ErrorLog(std::vformat(fmtloc.fmt, std::make_format_args(args...)),
+                                  this->error().message,
+                                  fmtloc.loc);
     }
     return std::move(*this);
   }
 
   template <typename... Args>
-  void or_log_error(std::format_string<Args...> fmt, Args &&...args)
+  void or_log_error(FmtWithLoc<std::type_identity_t<Args>...> fmtloc, Args &&...args)
     requires requires(Err e) { e.message; }
   {
     if (!this->has_value()) {
-      flatearth::detail::ErrorLog(std::format(fmt, std::forward<Args>(args)...),
-                                  this->error().message);
+      flatearth::detail::ErrorLog(std::vformat(fmtloc.fmt, std::make_format_args(args...)),
+                                  this->error().message,
+                                  fmtloc.loc);
     }
   }
 
   template <typename... Args>
-  void or_log_warn(std::format_string<Args...> fmt, Args &&...args)
+  void or_log_warn(FmtWithLoc<std::type_identity_t<Args>...> fmtloc, Args &&...args)
     requires requires(Err e) { e.message; }
   {
     if (!this->has_value()) {
-      flatearth::detail::WarnLog(std::format(fmt, std::forward<Args>(args)...),
-                                 this->error().message);
+      flatearth::detail::WarnLog(std::vformat(fmtloc.fmt, std::make_format_args(args...)),
+                                 this->error().message,
+                                 fmtloc.loc);
     } else {
-      flatearth::detail::WarnLog(std::format(fmt, std::forward<Args>(args)...));
+      flatearth::detail::WarnLog(
+          std::vformat(fmtloc.fmt, std::make_format_args(args...)), "", fmtloc.loc);
     }
   }
 

--- a/engine/src/Defines.hpp
+++ b/engine/src/Defines.hpp
@@ -3,7 +3,9 @@
 
 #include <atomic>
 #include <cstdint>
+#include <cstdlib>
 #include <expected>
+#include <format>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -57,6 +59,12 @@ STATIC_ASSERT(sizeof(float64) == 8, "Expected float64 to be 8 bytes");
 
 #define FeTrue true
 #define FeFalse false
+
+namespace flatearth::detail {
+[[noreturn]] void FatalLog(stringv userMsg, stringv errMsg);
+void ErrorLog(stringv userMsg, stringv errMsg);
+void WarnLog(stringv userMsg, stringv errMsg = "");
+} // namespace flatearth::detail
 
 // Platform detection
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__)
@@ -139,8 +147,94 @@ using FeSharedPtr = std::shared_ptr<T>;
 template <typename T, typename D>
 using FeCustomDeleterPtr = std::unique_ptr<T, D>;
 
+template <typename T>
+using FeOptional = std::optional<T>;
+
 template <typename Ret, typename Err>
-using FeExpect = std::expected<Ret, Err>;
+struct FeExpect : std::expected<Ret, Err> {
+  using Base = std::expected<Ret, Err>;
+  using Base::Base;
+
+  auto or_fatal(stringv msg)
+    requires requires(Err e) { e.message; }
+  {
+    if (!this->has_value()) {
+      flatearth::detail::FatalLog(msg, this->error().message);
+    }
+    if constexpr (!std::is_void_v<Ret>) {
+      return std::move(this->value());
+    }
+  }
+
+  template <typename... Args>
+  [[nodiscard]] FeExpect or_error(std::format_string<Args...> fmt, Args &&...args)
+    requires requires(Err e) { e.message; }
+  {
+    if (!this->has_value()) {
+      flatearth::detail::ErrorLog(std::format(fmt, std::forward<Args>(args)...),
+                                  this->error().message);
+    }
+    return std::move(*this);
+  }
+
+  template <typename... Args>
+  void or_log_error(std::format_string<Args...> fmt, Args &&...args)
+    requires requires(Err e) { e.message; }
+  {
+    if (!this->has_value()) {
+      flatearth::detail::ErrorLog(std::format(fmt, std::forward<Args>(args)...),
+                                  this->error().message);
+    }
+  }
+
+  template <typename... Args>
+  void or_log_warn(std::format_string<Args...> fmt, Args &&...args)
+    requires requires(Err e) { e.message; }
+  {
+    if (!this->has_value()) {
+      flatearth::detail::WarnLog(std::format(fmt, std::forward<Args>(args)...),
+                                 this->error().message);
+    } else {
+      flatearth::detail::WarnLog(std::format(fmt, std::forward<Args>(args)...));
+    }
+  }
+
+  bool errored() const
+    requires requires(Err e) { e.message; }
+  {
+    return !this->has_value();
+  }
+
+  template <typename Fn>
+  auto and_then(Fn &&fn) && {
+    if constexpr (std::is_void_v<Ret>) {
+      using ResultType = std::invoke_result_t<Fn>;
+      if (this->has_value())
+        return std::invoke(std::forward<Fn>(fn));
+      return ResultType(std::unexpect, std::move(this->error()));
+    } else {
+      using ResultType = std::invoke_result_t<Fn, Ret &&>;
+      if (this->has_value())
+        return std::invoke(std::forward<Fn>(fn), std::move(this->value()));
+      return ResultType(std::unexpect, std::move(this->error()));
+    }
+  }
+
+  template <typename Fn>
+  auto and_then(Fn &&fn) const & {
+    if constexpr (std::is_void_v<Ret>) {
+      using ResultType = std::invoke_result_t<Fn>;
+      if (this->has_value())
+        return std::invoke(std::forward<Fn>(fn));
+      return ResultType(std::unexpect, this->error());
+    } else {
+      using ResultType = std::invoke_result_t<Fn, const Ret &>;
+      if (this->has_value())
+        return std::invoke(std::forward<Fn>(fn), this->value());
+      return ResultType(std::unexpect, this->error());
+    }
+  }
+};
 
 template <typename Err>
 using FeErr = std::unexpected<Err>;
@@ -164,8 +258,12 @@ inline T *FeCastPermissive(void *ptr) {
 
 #define FECLAMP(value, min, max) (value <= min) ? min : (value >= max) ? max : value;
 
-template <typename T>
-using FeOptional = std::optional<T>;
+#define FE_RIPPLE(expr)                                          \
+  do {                                                           \
+    auto _fe_ripple_tmp = (expr);                                \
+    if (!_fe_ripple_tmp.has_value())                             \
+      return std::unexpected(std::move(_fe_ripple_tmp.error())); \
+  } while (0)
 
 #define FE_MOVE_ONLY(Type)                     \
   Type(Type &&) noexcept = default;            \

--- a/engine/src/ECS/EntityBuilder.cc
+++ b/engine/src/ECS/EntityBuilder.cc
@@ -1,0 +1,37 @@
+#include "EntityBuilder.hpp"
+#include "Core/FeMemory.hpp"
+#include "Core/Logger.hpp"
+
+namespace flatearth::ecs {
+
+EntityBuilder::EntityBuilder(memory::MemoryManager &mm, Registry &reg)
+  : _registry(reg), _memoryManager(mm), _inserts(mm) {}
+
+EntityBuilder::~EntityBuilder() {
+  if (_commited) {
+    return;
+  }
+
+  FLOG_WARN("EntityBuilder destroyed without Commit() - entity was never created");
+  for (uint64 i = 0; i < _inserts.Length(); i++) {
+    DeferredInsert &entry = _inserts[i];
+    _memoryManager.RawFree(entry.pData, entry.size, memory::Tag::Entity);
+  }
+}
+
+EntityId EntityBuilder::Commit() {
+  EntityId id = _registry.Create();
+  CarveEntity(id);
+  _commited = FeTrue;
+  return id;
+}
+
+void EntityBuilder::CarveEntity(EntityId id) {
+  for (uint64 i = 0; i < _inserts.Length(); i++) {
+    DeferredInsert &entry = _inserts[i];
+    entry.fn(_registry, id, entry.pData);
+    _memoryManager.RawFree(entry.pData, entry.size, memory::Tag::Entity);
+  }
+}
+
+}

--- a/engine/src/ECS/EntityBuilder.hpp
+++ b/engine/src/ECS/EntityBuilder.hpp
@@ -1,0 +1,61 @@
+#ifndef _FLATEARTH_ENGINE_ECS_ENTITY_BUILDER_HPP
+#define _FLATEARTH_ENGINE_ECS_ENTITY_BUILDER_HPP
+
+#include "Containers/DArray.hpp"
+#include "Core/FeMemory.hpp"
+#include "ECS/ECSTypes.hpp"
+#include "Scene/Scene.hpp"
+#include "ECS/Registry.hpp"
+
+namespace flatearth::ecs {
+
+class EntityBuilder {
+public:
+  explicit EntityBuilder(memory::MemoryManager &, Registry &);
+  ~EntityBuilder();
+
+  EntityId Commit();
+
+  template <typename T>
+  EntityBuilder &With(T component) {
+    static_assert(std::is_trivially_copyable_v<T>,
+                  "EntityBuilder::With<T> - T must be trivially copyable");
+
+    void *pData = _memoryManager.RawAlloc(sizeof(T), alignof(T), memory::Tag::Entity);
+    _memoryManager.FCopyMemory(pData, &component, sizeof(T));
+
+    _inserts.Push(DeferredInsert{
+      [](Registry &reg, EntityId id, const void *data) {
+        reg.Insert(id, *static_cast<const T *>(data));
+      },
+      pData,
+      sizeof(T),
+    });
+
+    return *this;
+  }
+
+  EntityBuilder &OwnedBy(scene::SceneId id) { return With(scene::SceneOwnership{id}); }
+
+private:
+  using InsertFn = void (*)(Registry &, EntityId, const void *);
+
+  struct DeferredInsert {
+    InsertFn fn{};
+    void *pData{nullptr};
+    uint64 size{0};
+  };
+
+private:
+  void CarveEntity(EntityId id);
+
+private:
+  Registry &_registry;
+  memory::MemoryManager &_memoryManager;
+  containers::DArray<DeferredInsert> _inserts;
+  bool _commited{FeFalse};
+};
+
+} // namespace flatearth::ecs
+
+#endif // _FLATEARTH_ENGINE_ECS_ENTITY_BUILDER_HPP

--- a/engine/src/ECS/Registry.cc
+++ b/engine/src/ECS/Registry.cc
@@ -2,6 +2,7 @@
 
 #include "Core/FeMemory.hpp"
 #include "Core/Logger.hpp"
+#include "ECS/EntityBuilder.hpp"
 
 namespace flatearth::ecs {
 
@@ -23,5 +24,7 @@ void Registry::Destroy(EntityId id) {
   _entityManager.Destroy(id);
   FLOG_DEBUG("entity '{}' destroyed", id);
 }
+
+EntityBuilder Registry::Spawn() { return EntityBuilder(_memoryManager, *this); }
 
 } // namespace flatearth::ecs

--- a/engine/src/ECS/Registry.hpp
+++ b/engine/src/ECS/Registry.hpp
@@ -9,12 +9,15 @@
 
 namespace flatearth::ecs {
 
+class EntityBuilder;
+
 class Registry {
 public:
   FEAPI explicit Registry(memory::MemoryManager &memManager);
 
   FEAPI EntityId Create();
   void Destroy(EntityId id);
+  FEAPI EntityBuilder Spawn();
 
   template <typename T>
   void Insert(EntityId id, const T &component) {
@@ -81,5 +84,9 @@ private:
 };
 
 } // namespace flatearth::ecs
+
+// Deferred include: EntityBuilder uses Registry, Registry returns EntityBuilder from Spawn().
+// Registry must be fully defined before EntityBuilder.hpp is processed.
+#include "ECS/EntityBuilder.hpp"
 
 #endif // _FLATEARTH_ENGINE_ECS_REGISTRY_HPP

--- a/engine/src/ECS/Scheduler/SystemScheduler.cc
+++ b/engine/src/ECS/Scheduler/SystemScheduler.cc
@@ -24,13 +24,10 @@ FeExpect<void, Error> SystemScheduler::Build() {
   // initialize inDegrees hash map
   HashMap<uint32, uint32> inDegree(_memoryManager);
   _nodesMap.ForEach([&](uint32 typeId, const auto &) {
-    auto res = inDegree.Insert(typeId, 0);
-    if (!res.has_value()) {
-      FLOG_WARN("failed to insert typeId {} into inDegree array. This initialization error may "
-                "lead to crashes and UB. Err: {}",
-                typeId,
-                res.error().message);
-    }
+    inDegree.Insert(typeId, 0)
+        .or_log_warn("failed to insert typeId {} into inDegree array. This initialization error "
+                     "may lead to crashes and UB.",
+                     typeId);
   });
 
   // build the adjacency list
@@ -47,10 +44,7 @@ FeExpect<void, Error> SystemScheduler::Build() {
       return;
     }
 
-    auto res = queue.Put(typeId);
-    if (!res.has_value()) {
-      FLOG_WARN("could not insert typeId {} into queue. Err: {}", typeId, res.error().message);
-    }
+    queue.Put(typeId).or_log_warn("could not insert typeId {} into queue", typeId);
   });
 
   uint32 processed = 0;
@@ -93,10 +87,7 @@ FeExpect<void, Error> SystemScheduler::Build() {
         continue;
       }
 
-      auto res = queue.Put(neighborId);
-      if (!res.has_value()) {
-        FLOG_ERROR("failed to put neighbor id in queue: {}", res.error().message);
-      }
+      queue.Put(neighborId).or_log_error("failed to put neighbor id in queue");
     }
   }
 
@@ -181,9 +172,8 @@ void BuildEdges(const FePtr<SystemNode> &node,
     containers::DArray<uint32> *pList = edges.Retrieve(x);
     if (pList == nullptr) {
       auto res = edges.Insert(x, std::move(containers::DArray<uint32>(memManager)));
-      if (!res.has_value()) {
-        FLOG_ERROR("failed to insert a new DArray while building edges. Err: {}",
-                   res.error().message);
+      res.or_log_error("failed to insert a new DArray while building edges");
+      if (res.errored()) {
         continue;
       }
       pList = edges.Retrieve(x);
@@ -196,9 +186,8 @@ void BuildEdges(const FePtr<SystemNode> &node,
     containers::DArray<uint32> *pList = edges.Retrieve(node->typeId);
     if (pList == nullptr) {
       auto res = edges.Insert(node->typeId, std::move(containers::DArray<uint32>(memManager)));
-      if (!res.has_value()) {
-        FLOG_ERROR("failed to insert a new DArray while building edges. Err: {}",
-                   res.error().message);
+      res.or_log_error("failed to insert a new DArray while building edges");
+      if (res.errored()) {
         continue;
       }
       pList = edges.Retrieve(node->typeId);

--- a/engine/src/ECS/Scheduler/SystemScheduler.hpp
+++ b/engine/src/ECS/Scheduler/SystemScheduler.hpp
@@ -56,9 +56,8 @@ public:
     pNode->pSystem =
         _memoryManager.Allocate<ISystem, T>(memory::Tag::Entity, std::forward<Args>(args)...);
     SystemBuilder builder{*pNode};
-    auto res = _nodesMap.Insert(typeId, std::move(pNode));
-    if (!res.has_value()) {
-      FLOG_ERROR("failed to insert system node into hashmap: {}", res.error().message);
+    auto res = _nodesMap.Insert(typeId, std::move(pNode)).or_error("failed to insert system node into hashmap");
+    if (res.errored()) {
       return FeErr{res.error()};
     }
 

--- a/engine/src/Error.hpp
+++ b/engine/src/Error.hpp
@@ -16,9 +16,7 @@ enum class ErrorType {
   NoBackendRenderer,
   GameInitializeUndefined,
   RendererVulkanError,
-  SystemError,
   RendererSelectPhysicalDevice,
-  FileReadError,
   GameUpdateUndefined,
   PlatformCreateSurface,
   GameResizeUndefined,
@@ -30,6 +28,8 @@ enum class ErrorType {
   MathError,
   NullptrException,
   LogicalError,
+  SystemError,
+  FileReadError,
 };
 
 struct Error {

--- a/engine/src/Modules/AssetModule.cc
+++ b/engine/src/Modules/AssetModule.cc
@@ -4,9 +4,9 @@
 
 namespace flatearth::modules {
 
-FeExpect<bool, Error> Assets::Initialize(renderer::FrontendRenderer *pRenderer) {
+FeExpect<void, Error> Assets::Initialize(renderer::FrontendRenderer *pRenderer) {
   if (_initialized) {
-    return FeFalse;
+    return {};
   }
 
   if (pRenderer == nullptr) {
@@ -16,7 +16,7 @@ FeExpect<bool, Error> Assets::Initialize(renderer::FrontendRenderer *pRenderer) 
 
   _manager.Initialize(pRenderer);
   _initialized = FeTrue;
-  return FeTrue;
+  return {};
 }
 
 void Assets::Shutdown() {

--- a/engine/src/Modules/AssetModule.hpp
+++ b/engine/src/Modules/AssetModule.hpp
@@ -13,7 +13,7 @@ public:
   explicit Assets(memory::MemoryManager &mm, platform::FileSystem &fs, ecs::Registry &reg)
       : _manager(mm, fs), _tilemap(mm, _manager, reg), _prefab(mm) {}
 
-  FeExpect<bool, Error> Initialize(renderer::FrontendRenderer *pRenderer);
+  FeExpect<void, Error> Initialize(renderer::FrontendRenderer *pRenderer);
   void Shutdown();
 
   FEAPI assets::AssetManager &Manager() { return _manager; }

--- a/engine/src/Modules/CoreModule.cc
+++ b/engine/src/Modules/CoreModule.cc
@@ -2,18 +2,18 @@
 
 namespace flatearth::modules {
 
-FeExpect<bool, Error> Core::Initialize() {
+FeExpect<void, Error> Core::Initialize() {
   if (_initialized) {
-    return FeFalse;
+    return {};
   }
 
   auto initRes = _audio.Initialize();
-  if (!initRes.has_value()) {
+  if (initRes.errored()) {
     return FeErr{initRes.error()};
   }
 
   _initialized = FeTrue;
-  return FeTrue;
+  return {};
 }
 
 void Core::Shutdown() {

--- a/engine/src/Modules/CoreModule.hpp
+++ b/engine/src/Modules/CoreModule.hpp
@@ -15,7 +15,7 @@ public:
       : _memoryManager(mm), _input(em), _audio(mm), _kvars(mm) {
   }
 
-  FeExpect<bool, Error> Initialize();
+  FeExpect<void, Error> Initialize();
   void Shutdown();
 
   // Gives access to Core Memory internals

--- a/engine/src/Modules/GameModule.cc
+++ b/engine/src/Modules/GameModule.cc
@@ -1,15 +1,17 @@
 #include "GameModule.hpp"
 
+#include <vector>
+
 namespace flatearth::modules {
 
-FeExpect<bool, Error> Project::Initialize(float32 gravityX, float32 gravityY) {
+FeExpect<void, Error> Project::Initialize(float32 gravityX, float32 gravityY) {
   if (_initialized) {
-    return FeFalse;
+    return {};
   }
 
   _world.Initialize(gravityX, gravityY);
   _initialized = FeTrue;
-  return FeTrue;
+  return {};
 }
 
 void Project::Shutdown() {
@@ -21,4 +23,38 @@ void Project::Shutdown() {
   _initialized = FeFalse;
 }
 
+scene::SceneId Project::RegisterScene(stringv name) {
+  const string key{name};
+  scene::SceneId *pExisting = _sceneNameMap.Retrieve(key);
+  if (pExisting != nullptr) {
+    return *pExisting;
+  }
+
+  scene::SceneId id = _nextSceneId++;
+  auto _ = _sceneNameMap.Insert(key, id);
+  return id;
 }
+
+void Project::DestroyScene(scene::SceneId id) {
+  if (id == scene::cNullScene) {
+    return;
+  }
+
+  std::vector<ecs::EntityId> toDestroy;
+  for (auto [eid, ownership] : _registry.ViewOf<scene::SceneOwnership>()) {
+    if (ownership.sceneId == id) {
+      toDestroy.push_back(eid);
+    }
+  }
+  for (auto eid : toDestroy) {
+    _registry.Destroy(eid);
+  }
+}
+
+scene::SceneId Project::GetSceneId(stringv name) {
+  const string key{name};
+  scene::SceneId *p = _sceneNameMap.Retrieve(key);
+  return p ? *p : scene::cNullScene;
+}
+
+} // namespace flatearth::modules

--- a/engine/src/Modules/GameModule.hpp
+++ b/engine/src/Modules/GameModule.hpp
@@ -1,18 +1,24 @@
 #ifndef _FLATEARTH_ENGINE_MODULES_GAME_MODULE_HPP
 #define _FLATEARTH_ENGINE_MODULES_GAME_MODULE_HPP
 
+#include "Containers/HashMap.hpp"
 #include "ECS/Registry.hpp"
 #include "Physics/FlatearthWorld.hpp"
+#include "Scene/Scene.hpp"
 
 namespace flatearth::modules {
 
 class Project {
 public:
   explicit Project(memory::MemoryManager &mm, ecs::Registry &reg)
-      : _registry(reg), _world(mm) {}
+      : _memoryManager(mm), _registry(reg), _world(mm), _sceneNameMap(mm) {}
 
-  FeExpect<bool, Error> Initialize(float32 gravityX = 0.0f, float32 gravityY = -9.8f);
+  FeExpect<void, Error> Initialize(float32 gravityX = 0.0f, float32 gravityY = -9.8f);
   void Shutdown();
+
+  FEAPI scene::SceneId RegisterScene(stringv name);
+  FEAPI void DestroyScene(scene::SceneId id);
+  FEAPI scene::SceneId GetSceneId(stringv name);
 
   FEAPI ecs::Registry &Registry() { return _registry; }
   FEAPI const ecs::Registry &Registry() const { return _registry; }
@@ -21,9 +27,12 @@ public:
   FEAPI const physics::FlatearthWorld &World() const { return _world; }
 
 private:
+  memory::MemoryManager &_memoryManager;
   ecs::Registry &_registry;
 
   physics::FlatearthWorld _world;
+  containers::HashMap<string, scene::SceneId> _sceneNameMap;
+  scene::SceneId _nextSceneId{1};
   bool _initialized{FeFalse};
 };
 

--- a/engine/src/Platform/LinuxPlatform.cc
+++ b/engine/src/Platform/LinuxPlatform.cc
@@ -77,7 +77,7 @@ FeExpect<void, Error> CreateVulkanSurface(PlatformState *platState,
 }
 
 input::Keys TranslateKeySymbol(uint32 keySym);
-ImGuiKey   TranslateToImGuiKey(uint32 keySym);
+ImGuiKey TranslateToImGuiKey(uint32 keySym);
 
 const string cNullInternalStateError = "platform internal state is nullptr";
 const string cXCBConnectionError = "XCB failed to connect";
@@ -242,9 +242,10 @@ FeExpect<bool, Error> Platform::PollEvents() {
           io.AddInputCharacter((unsigned int)keySymbol);
         }
 
-        auto processRes = _inputManager.ProcessKey(key, pressed);
-        if (!processRes.has_value()) {
-          FLOG_ERROR("input manager failed to process key {} event", (uint32)keySymbol);
+        auto processRes =
+            _inputManager.ProcessKey(key, pressed)
+                .or_error("input manager failed to proceess key {} event", (uint32)keySymbol);
+        if (processRes.errored()) {
           break;
         }
 
@@ -273,9 +274,9 @@ FeExpect<bool, Error> Platform::PollEvents() {
           break;
         }
 
-        auto buttonRes = _inputManager.ProcessButton(button, pressed);
-        if (!buttonRes.has_value()) {
-          FLOG_ERROR("input manager failed to process mouse click");
+        auto buttonRes = _inputManager.ProcessButton(button, pressed)
+                             .or_error("input manager failed to process mouse click");
+        if (buttonRes.errored()) {
           break;
         }
 
@@ -285,9 +286,9 @@ FeExpect<bool, Error> Platform::PollEvents() {
       } break;
       case XCB_MOTION_NOTIFY: {
         xcb_motion_notify_event_t *moveEvent = (xcb_motion_notify_event_t *)event;
-        auto moveRes = _inputManager.ProcessMouseMove(moveEvent->event_x, moveEvent->event_y);
-        if (!moveRes.has_value()) {
-          FLOG_ERROR("input manager failed to process mouse move");
+        auto moveRes = _inputManager.ProcessMouseMove(moveEvent->event_x, moveEvent->event_y)
+                           .or_error("input manager failed to process mouse move");
+        if (moveRes.errored()) {
           break;
         }
 
@@ -303,11 +304,8 @@ FeExpect<bool, Error> Platform::PollEvents() {
             configureEvent->height,
         };
         eventCtx.Set(event::EventLayout::Uint32x4, resizePayload);
-        auto res =
-            _eventManager.FireEvent(event::SystemEventCode::WindowResized, nullptr, eventCtx);
-        if (!res.has_value()) {
-          FLOG_ERROR("event manager failed to fire resize event: {}", res.error().message);
-        }
+        _eventManager.FireEvent(event::SystemEventCode::WindowResized, nullptr, eventCtx)
+            .or_log_error("event manager failed to fire resize event");
       } break;
       case XCB_CLIENT_MESSAGE: {
         auto *cm = (xcb_client_message_event_t *)event;
@@ -608,33 +606,65 @@ input::Keys TranslateKeySymbol(uint32 keySymbol) {
 
 ImGuiKey TranslateToImGuiKey(uint32 keySym) {
   switch (keySym) {
-    case XK_BackSpace:  return ImGuiKey_Backspace;
-    case XK_Return:     return ImGuiKey_Enter;
-    case XK_KP_Enter:   return ImGuiKey_KeypadEnter;
-    case XK_Tab:        return ImGuiKey_Tab;
-    case XK_Escape:     return ImGuiKey_Escape;
-    case XK_Delete:     return ImGuiKey_Delete;
-    case XK_Insert:     return ImGuiKey_Insert;
-    case XK_Home:       return ImGuiKey_Home;
-    case XK_End:        return ImGuiKey_End;
-    case XK_Prior:      return ImGuiKey_PageUp;
-    case XK_Next:       return ImGuiKey_PageDown;
-    case XK_Left:       return ImGuiKey_LeftArrow;
-    case XK_Right:      return ImGuiKey_RightArrow;
-    case XK_Up:         return ImGuiKey_UpArrow;
-    case XK_Down:       return ImGuiKey_DownArrow;
-    case XK_Shift_L:    return ImGuiKey_LeftShift;
-    case XK_Shift_R:    return ImGuiKey_RightShift;
-    case XK_Control_L:  return ImGuiKey_LeftCtrl;
-    case XK_Control_R:  return ImGuiKey_RightCtrl;
-    case XK_Alt_L:      return ImGuiKey_LeftAlt;
-    case XK_Alt_R:      return ImGuiKey_RightAlt;
-    case XK_a: case XK_A: return ImGuiKey_A;
-    case XK_c: case XK_C: return ImGuiKey_C;
-    case XK_v: case XK_V: return ImGuiKey_V;
-    case XK_x: case XK_X: return ImGuiKey_X;
-    case XK_z: case XK_Z: return ImGuiKey_Z;
-    default: return ImGuiKey_None;
+    case XK_BackSpace:
+      return ImGuiKey_Backspace;
+    case XK_Return:
+      return ImGuiKey_Enter;
+    case XK_KP_Enter:
+      return ImGuiKey_KeypadEnter;
+    case XK_Tab:
+      return ImGuiKey_Tab;
+    case XK_Escape:
+      return ImGuiKey_Escape;
+    case XK_Delete:
+      return ImGuiKey_Delete;
+    case XK_Insert:
+      return ImGuiKey_Insert;
+    case XK_Home:
+      return ImGuiKey_Home;
+    case XK_End:
+      return ImGuiKey_End;
+    case XK_Prior:
+      return ImGuiKey_PageUp;
+    case XK_Next:
+      return ImGuiKey_PageDown;
+    case XK_Left:
+      return ImGuiKey_LeftArrow;
+    case XK_Right:
+      return ImGuiKey_RightArrow;
+    case XK_Up:
+      return ImGuiKey_UpArrow;
+    case XK_Down:
+      return ImGuiKey_DownArrow;
+    case XK_Shift_L:
+      return ImGuiKey_LeftShift;
+    case XK_Shift_R:
+      return ImGuiKey_RightShift;
+    case XK_Control_L:
+      return ImGuiKey_LeftCtrl;
+    case XK_Control_R:
+      return ImGuiKey_RightCtrl;
+    case XK_Alt_L:
+      return ImGuiKey_LeftAlt;
+    case XK_Alt_R:
+      return ImGuiKey_RightAlt;
+    case XK_a:
+    case XK_A:
+      return ImGuiKey_A;
+    case XK_c:
+    case XK_C:
+      return ImGuiKey_C;
+    case XK_v:
+    case XK_V:
+      return ImGuiKey_V;
+    case XK_x:
+    case XK_X:
+      return ImGuiKey_X;
+    case XK_z:
+    case XK_Z:
+      return ImGuiKey_Z;
+    default:
+      return ImGuiKey_None;
   }
 }
 

--- a/engine/src/Renderer/GameRenderer.cc
+++ b/engine/src/Renderer/GameRenderer.cc
@@ -15,7 +15,7 @@ GameRenderer::GameRenderer(EngineState *pEngState,
     : _memoryManager(memManager), _frontendRenderer(pEngState, memManager, fs), _registry(reg) {
 }
 
-FeExpect<bool, Error> GameRenderer::Initialize() {
+FeExpect<void, Error> GameRenderer::Initialize() {
   return _frontendRenderer.Initialize();
 }
 

--- a/engine/src/Renderer/GameRenderer.hpp
+++ b/engine/src/Renderer/GameRenderer.hpp
@@ -13,7 +13,7 @@ public:
   explicit GameRenderer(EngineState *pEngState, memory::MemoryManager &memManager,
                               ecs::Registry &registry, platform::FileSystem &fs);
 
-  FeExpect<bool, Error> Initialize();
+  FeExpect<void, Error> Initialize();
   FeExpect<bool, Error> Draw(float32 deltaTime);
   void BeginImGuiFrame();
 

--- a/engine/src/Renderer/RendererFrontend.cc
+++ b/engine/src/Renderer/RendererFrontend.cc
@@ -37,12 +37,12 @@ void FrontendRenderer::Shutdown() {
   _materialCache.Shutdown();
 }
 
-FeExpect<bool, Error> FrontendRenderer::Initialize() {
+FeExpect<void, Error> FrontendRenderer::Initialize() {
   if (_pEngState->pAppConfig)
     _applicationName = _pEngState->pAppConfig->name;
 
   auto backendsRes = MakeBackends();
-  if (!backendsRes.has_value()) {
+  if (backendsRes.errored()) {
     FLOG_ERROR("failed to scaffold renderer backends: {}", backendsRes.error().message);
     return FeErr{backendsRes.error()};
   }
@@ -56,7 +56,7 @@ FeExpect<bool, Error> FrontendRenderer::Initialize() {
 
   _rendererState.pActiveBackend = _pBackends[vulkanIndex].get();
   auto backendInitRes = _rendererState.pActiveBackend->Initialize(_pEngState);
-  if (!backendInitRes.has_value()) {
+  if (backendInitRes.errored()) {
     FLOG_ERROR("failed to initialize backend renderer");
     return FeErr{backendInitRes.error()};
   }
@@ -67,7 +67,7 @@ FeExpect<bool, Error> FrontendRenderer::Initialize() {
       -aspect, aspect, -1.0f, 1.0f, _rendererState.nearClip, _rendererState.farClip);
 
   FLOG_INFO("frontend renderer successfully initialized");
-  return FeTrue;
+  return {};
 }
 
 FeExpect<bool, Error> FrontendRenderer::BeginFrame(float32 deltaTime) {
@@ -77,7 +77,7 @@ FeExpect<bool, Error> FrontendRenderer::BeginFrame(float32 deltaTime) {
   }
 
   auto res = _rendererState.pActiveBackend->BeginFrame(deltaTime);
-  if (!res.has_value()) {
+  if (res.errored()) {
     FLOG_ERROR("backend renderer failed to begin frame");
     return FeErr{res.error()};
   }
@@ -92,7 +92,7 @@ FeExpect<bool, Error> FrontendRenderer::EndFrame(float32 deltaTime) {
   }
 
   auto res = _rendererState.pActiveBackend->EndFrame(deltaTime);
-  if (!res.has_value()) {
+  if (res.errored()) {
     FLOG_ERROR("backend renderer failed to end frame");
     return FeErr{res.error()};
   }
@@ -107,7 +107,7 @@ FeExpect<bool, Error> FrontendRenderer::DrawFrame(RenderPacket *pRenderPacket) {
   }
 
   auto beginRes = BeginFrame(pRenderPacket->deltaTime);
-  if (!beginRes.has_value()) {
+  if (beginRes.errored()) {
     FLOG_ERROR("failed to begin frame");
     return FeErr{beginRes.error()};
   }
@@ -119,7 +119,7 @@ FeExpect<bool, Error> FrontendRenderer::DrawFrame(RenderPacket *pRenderPacket) {
 
   auto updateRes = _rendererState.pActiveBackend->UpdateGlobalState(
       _rendererState.projection, pRenderPacket->view, math::Vec3D::Zero(), 0);
-  if (!updateRes.has_value()) {
+  if (updateRes.errored()) {
     FLOG_ERROR("failed to update global state on frontend renderer");
     return FeErr{updateRes.error()};
   }
@@ -146,7 +146,7 @@ FeExpect<bool, Error> FrontendRenderer::DrawFrame(RenderPacket *pRenderPacket) {
   _rendererState.pActiveBackend->DrawImGui();
 
   auto endRes = EndFrame(pRenderPacket->deltaTime);
-  if (!endRes.has_value()) {
+  if (endRes.errored()) {
     FLOG_ERROR("failed to end frame");
     return FeErr{endRes.error()};
   }
@@ -164,7 +164,7 @@ FeExpect<void, Error> FrontendRenderer::OnResize(uint32 width, uint32 height) {
   _rendererState.projection = math::Mat4D::Orthographic(
       -aspect, aspect, -1.0f, 1.0f, _rendererState.nearClip, _rendererState.farClip);
   auto res = _rendererState.pActiveBackend->OnResize(width, height);
-  if (!res.has_value()) {
+  if (res.errored()) {
     FLOG_ERROR("backend renderer failed to resize");
     return FeErr{res.error()};
   }

--- a/engine/src/Renderer/RendererFrontend.hpp
+++ b/engine/src/Renderer/RendererFrontend.hpp
@@ -24,7 +24,7 @@ public:
                             platform::FileSystem &fs);
   ~FrontendRenderer();
 
-  FeExpect<bool, Error> Initialize();
+  FeExpect<void, Error> Initialize();
   FeExpect<bool, Error> BeginFrame(float32 deltaTime);
   FeExpect<bool, Error> EndFrame(float32 deltaTime);
   FeExpect<bool, Error> DrawFrame(RenderPacket *pRenderPacket);

--- a/engine/src/Renderer/Vulkan/Shaders/ObjectShader.cc
+++ b/engine/src/Renderer/Vulkan/Shaders/ObjectShader.cc
@@ -110,7 +110,7 @@ FeExpect<bool, Error> VulkanShader::CreateObjectShader(Context &ctx, ObjectShade
                                         cStageTypes[i],
                                         i,
                                         pObjShader->shaderStages.data());
-    if (!createRes.has_value()) {
+    if (createRes.errored()) {
       FLOG_ERROR("failed to create shader module at index {}", i);
       return FeErr{createRes.error()};
     }
@@ -120,7 +120,7 @@ FeExpect<bool, Error> VulkanShader::CreateObjectShader(Context &ctx, ObjectShade
   // -----------------------------
   // Global descriptor set layout
   // -----------------------------
-  if (auto res = MakeLayoutBinding(ctx, pObjShader, DescriptorBinding::Global); !res.has_value()) {
+  if (auto res = MakeLayoutBinding(ctx, pObjShader, DescriptorBinding::Global); res.errored()) {
     FLOG_ERROR("failed to create global descriptor set layout");
     return FeErr{res.error()};
   }
@@ -128,7 +128,7 @@ FeExpect<bool, Error> VulkanShader::CreateObjectShader(Context &ctx, ObjectShade
   // -----------------------------
   // Texture descriptor and layout
   // -----------------------------
-  if (auto res = MakeLayoutBinding(ctx, pObjShader, DescriptorBinding::Texture); !res.has_value()) {
+  if (auto res = MakeLayoutBinding(ctx, pObjShader, DescriptorBinding::Texture); res.errored()) {
     FLOG_ERROR("failed to create texture descriptor set layout");
     return FeErr{res.error()};
   }
@@ -136,7 +136,7 @@ FeExpect<bool, Error> VulkanShader::CreateObjectShader(Context &ctx, ObjectShade
   // -----------------------------
   // Descriptor pool
   // -----------------------------
-  if (auto res = MakeDescriptorPool(ctx, pObjShader, DescriptorBinding::Global); !res.has_value()) {
+  if (auto res = MakeDescriptorPool(ctx, pObjShader, DescriptorBinding::Global); res.errored()) {
     FLOG_ERROR("failed to create global descriptor pool");
     return FeErr{res.error()};
   }
@@ -145,7 +145,7 @@ FeExpect<bool, Error> VulkanShader::CreateObjectShader(Context &ctx, ObjectShade
   // Texture pool
   // -----------------------------
   if (auto res = MakeDescriptorPool(ctx, pObjShader, DescriptorBinding::Texture);
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to create texture descriptor pool");
     return FeErr{res.error()};
   }
@@ -208,7 +208,7 @@ FeExpect<bool, Error> VulkanShader::CreateObjectShader(Context &ctx, ObjectShade
                                                              scissor,
                                                              FeFalse,
                                                              &pObjShader->pipeline);
-  if (!pipelineRes.has_value()) {
+  if (pipelineRes.errored()) {
     FLOG_ERROR("failed to create graphics pipeline");
     return FeErr{pipelineRes.error()};
   }
@@ -221,7 +221,7 @@ FeExpect<bool, Error> VulkanShader::CreateObjectShader(Context &ctx, ObjectShade
 
   auto createBufferRes = _bufferManager.CreateVulkanBuffer(
       ctx, sizeof(GlobalUniformObject), usage, memFlags, FeTrue, &pObjShader->globalUniformBuffer);
-  if (!createBufferRes.has_value()) {
+  if (createBufferRes.errored()) {
     FLOG_ERROR("failed to create vulkan buffer for GlobalUniformObject");
     return FeErr{createBufferRes.error()};
   }
@@ -248,7 +248,7 @@ FeExpect<bool, Error> VulkanShader::CreateObjectShader(Context &ctx, ObjectShade
 
   if (auto res = VkCheck(vkAllocateDescriptorSets(
           ctx.device.logicalDevice, &allocInfo, pObjShader->globalDescriptorSets.Data()));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to allocate descriptor sets");
     return FeErr{res.error()};
   }
@@ -332,7 +332,7 @@ FeExpect<void, Error> VulkanShader::UpdateGlobalState(Context &ctx, ObjectShader
 
   auto loadRes = _bufferManager.LoadData(
       ctx, objShader.globalUniformBuffer, cOffset, cRange, 0, &objShader.globalUBO);
-  if (!loadRes.has_value()) {
+  if (loadRes.errored()) {
     FLOG_ERROR("failed to load data while updating global state");
     return FeErr{loadRes.error()};
   }
@@ -364,7 +364,7 @@ FeExpect<void, Error> VulkanShader::AcquireTextureResources(Context &ctx,
 
   if (auto res = VkCheck(vkAllocateDescriptorSets(
           ctx.device.logicalDevice, &allocInfo, &objShader.textureDescriptorSet));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to allocate texture descriptor set");
     return FeErr{res.error()};
   }

--- a/engine/src/Renderer/Vulkan/VulkanBackend.cc
+++ b/engine/src/Renderer/Vulkan/VulkanBackend.cc
@@ -55,32 +55,32 @@ VulkanBackend::~VulkanBackend() {
     }
 
     auto destroyRes = DestroyFence(&_ctx.inFlightFences[i]);
-    if (!destroyRes.has_value()) {
+    if (destroyRes.errored()) {
       FLOG_ERROR("Vulkan backend did not shutdown gracefully: {}", destroyRes.error().message);
       return;
     }
   }
 
   auto destroyRes = _cmdBufferManager.DestroyBuffers(_ctx);
-  if (!destroyRes.has_value()) {
+  if (destroyRes.errored()) {
     FLOG_ERROR("Vulkan backend did not shutdown gracefully: {}", destroyRes.error().message);
     return;
   }
 
   destroyRes = _renderpassManager.DestroyRenderpass(_ctx, &_ctx.mainRenderpass);
-  if (!destroyRes.has_value()) {
+  if (destroyRes.errored()) {
     FLOG_ERROR("Vulkan backend did not shutdown gracefully: {}", destroyRes.error().message);
     return;
   }
 
   destroyRes = _swapchainManager.DestroySwapchain(_ctx, &_ctx.swapchain);
-  if (!destroyRes.has_value()) {
+  if (destroyRes.errored()) {
     FLOG_ERROR("Vulkan backend did not shutdown gracefully: {}", destroyRes.error().message);
     return;
   }
 
   destroyRes = _deviceManager.DestroyDevice(_ctx);
-  if (!destroyRes.has_value()) {
+  if (destroyRes.errored()) {
     FLOG_ERROR("Vulkan backend did not shutdown gracefully: {}", destroyRes.error().message);
     return;
   }
@@ -137,7 +137,7 @@ FeExpect<bool, Error> VulkanBackend::Initialize(EngineState *pEngState) {
   // Obtain list of available layers
   uint32 availableLayerCount = 0;
   if (auto res = VkCheck(vkEnumerateInstanceLayerProperties(&availableLayerCount, nullptr));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to enumerate instance layer porperty count");
     return FeErr{res.error()};
   }
@@ -146,7 +146,7 @@ FeExpect<bool, Error> VulkanBackend::Initialize(EngineState *pEngState) {
   availableLayers.Reserve(availableLayerCount);
   if (auto res =
           VkCheck(vkEnumerateInstanceLayerProperties(&availableLayerCount, availableLayers.Data()));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to enumerate instance layer properties");
     return FeErr{res.error()};
   }
@@ -178,7 +178,7 @@ FeExpect<bool, Error> VulkanBackend::Initialize(EngineState *pEngState) {
   createInfo.ppEnabledLayerNames = requiredValidationLayerNames.Data();
 
   if (auto res = VkCheck(vkCreateInstance(&createInfo, _ctx.pAllocator, &_ctx.instance));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to create Vulkan instance");
     return FeErr{res.error()};
   }
@@ -204,7 +204,7 @@ FeExpect<bool, Error> VulkanBackend::Initialize(EngineState *pEngState) {
                                                                 "vkCreateDebugUtilsMessengerEXT");
   if (auto res =
           VkCheck(func(_ctx.instance, &debugCreateInfo, _ctx.pAllocator, &_ctx.debugMessenger));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to get instance proc address");
     return FeErr{res.error()};
   }
@@ -212,14 +212,14 @@ FeExpect<bool, Error> VulkanBackend::Initialize(EngineState *pEngState) {
 #endif
 
   FLOG_DEBUG("creating Vulkan surface");
-  if (auto res = platform::CreateVulkanSurface(pEngState->platformState, _ctx); !res.has_value()) {
+  if (auto res = platform::CreateVulkanSurface(pEngState->platformState, _ctx); res.errored()) {
     FLOG_ERROR("failed to create Vulkan surface");
     return FeErr{res.error()};
   }
   FLOG_DEBUG("Vulkan surface created");
 
   auto deviceRes = _deviceManager.CreateDevice(_ctx);
-  if (!deviceRes.has_value()) {
+  if (deviceRes.errored()) {
     FLOG_ERROR("failed to create device");
     return FeErr{deviceRes.error()};
   }
@@ -227,7 +227,7 @@ FeExpect<bool, Error> VulkanBackend::Initialize(EngineState *pEngState) {
   FLOG_DEBUG("creating swapchain");
   auto swapRes = _swapchainManager.CreateSwapchain(
       _ctx, &_ctx.swapchain, _ctx.framebufferWidth, _ctx.framebufferHeight);
-  if (!swapRes.has_value()) {
+  if (swapRes.errored()) {
     FLOG_ERROR("failed to create swapchain");
     return FeErr{swapRes.error()};
   }
@@ -246,7 +246,7 @@ FeExpect<bool, Error> VulkanBackend::Initialize(EngineState *pEngState) {
                                                       1.0f,
                                                       1.0f,
                                                       0);
-  if (!rpassRes.has_value()) {
+  if (rpassRes.errored()) {
     FLOG_ERROR("failed to create renderpass");
     return FeErr{rpassRes.error()};
   }
@@ -260,7 +260,7 @@ FeExpect<bool, Error> VulkanBackend::Initialize(EngineState *pEngState) {
 
   auto frameBufRes =
       _swapchainManager.RegenerateFrameBuffer(_ctx, &_ctx.swapchain, &_ctx.mainRenderpass);
-  if (!frameBufRes.has_value()) {
+  if (frameBufRes.errored()) {
     FLOG_ERROR("failed regenerating frame buffers");
     return FeErr{frameBufRes.error()};
   }
@@ -268,7 +268,7 @@ FeExpect<bool, Error> VulkanBackend::Initialize(EngineState *pEngState) {
 
   FLOG_DEBUG("creating command buffers");
   auto cmdBufRes = _cmdBufferManager.CreateBuffers(_ctx);
-  if (!cmdBufRes.has_value()) {
+  if (cmdBufRes.errored()) {
     FLOG_ERROR("failed to create command buffers");
     return FeErr{cmdBufRes.error()};
   }
@@ -285,13 +285,13 @@ FeExpect<bool, Error> VulkanBackend::Initialize(EngineState *pEngState) {
                                              &semaphoreInfo,
                                              _ctx.pAllocator,
                                              &_ctx.imageAvailableSemaphores[i]));
-        !res.has_value()) {
+        res.errored()) {
       FLOG_ERROR("failed to create image available semaphore");
       return FeErr{res.error()};
     }
 
     auto fenceRes = CreateFence(&_ctx.inFlightFences[i], FeTrue);
-    if (!fenceRes.has_value()) {
+    if (fenceRes.errored()) {
       FLOG_ERROR("failed to create in-flight fence");
       return FeErr{fenceRes.error()};
     }
@@ -308,7 +308,7 @@ FeExpect<bool, Error> VulkanBackend::Initialize(EngineState *pEngState) {
                                              &semaphoreInfo,
                                              _ctx.pAllocator,
                                              &_ctx.queueCompleteSemaphores[i]));
-        !res.has_value()) {
+        res.errored()) {
       FLOG_ERROR("failed to create queue complete semaphore");
       return FeErr{res.error()};
     }
@@ -325,14 +325,14 @@ FeExpect<bool, Error> VulkanBackend::Initialize(EngineState *pEngState) {
 
   // create builtin shaders
   auto shaderRes = _vulkanShader.CreateObjectShader(_ctx, &_ctx.objectShader);
-  if (!shaderRes.has_value()) {
+  if (shaderRes.errored()) {
     FLOG_ERROR("failed to create object shader");
     return FeErr{shaderRes.error()};
   }
 
   // create vulkan buffer
   auto createBufferRes = CreateBuffers();
-  if (!createBufferRes.has_value()) {
+  if (createBufferRes.errored()) {
     FLOG_ERROR("vulkan buffers creation failed");
     return FeErr{createBufferRes.error()};
   }
@@ -388,13 +388,13 @@ FeExpect<bool, Error> VulkanBackend::BeginFrame(float32 deltaTime) {
     FLOG_INFO("new framebuffer size: {}/{}", _cachedFrameBufferWidth, _cachedFrameBufferHeight);
     auto swapRes = _swapchainManager.RecreateSwapchain(
         _ctx, _cachedFrameBufferWidth, _cachedFrameBufferHeight);
-    if (!swapRes.has_value()) {
+    if (swapRes.errored()) {
       FLOG_ERROR("failed to recreate swapchain");
       return FeErr{swapRes.error()};
     }
 
     auto cmdBufRes = _cmdBufferManager.CreateBuffers(_ctx);
-    if (!cmdBufRes.has_value()) {
+    if (cmdBufRes.errored()) {
       FLOG_ERROR("failed to recreate command buffers");
       return FeErr{cmdBufRes.error()};
     }
@@ -403,7 +403,7 @@ FeExpect<bool, Error> VulkanBackend::BeginFrame(float32 deltaTime) {
   }
 
   auto awaitRes = AwaitFence(&_ctx.inFlightFences[_ctx.currentFrame], UINT64_MAX);
-  if (!awaitRes.has_value()) {
+  if (awaitRes.errored()) {
     FLOG_ERROR("failed to await in-flight fence");
     return FeErr{awaitRes.error()};
   }
@@ -416,7 +416,7 @@ FeExpect<bool, Error> VulkanBackend::BeginFrame(float32 deltaTime) {
                                          _ctx.imageAvailableSemaphores[_ctx.currentFrame],
                                          cFence,
                                          &_ctx.imageIndex);
-  if (!acquireRes.has_value()) {
+  if (acquireRes.errored()) {
     FLOG_ERROR("failed to acquire next image from swapchain");
     return FeErr{acquireRes.error()};
   }
@@ -444,7 +444,7 @@ FeExpect<bool, Error> VulkanBackend::EndFrame(float32 deltaTime) {
 
   if (_ctx.imagesInFlight[_ctx.imageIndex] != VK_NULL_HANDLE) {
     auto awaitRes = AwaitFence(_ctx.imagesInFlight[_ctx.imageIndex], UINT64_MAX);
-    if (!awaitRes.has_value()) {
+    if (awaitRes.errored()) {
       FLOG_ERROR("failed to await image in-flight fence");
       return FeErr{awaitRes.error()};
     }
@@ -453,7 +453,7 @@ FeExpect<bool, Error> VulkanBackend::EndFrame(float32 deltaTime) {
   _ctx.imagesInFlight[_ctx.imageIndex] = &_ctx.inFlightFences[_ctx.currentFrame];
 
   auto resetRes = ResetFence(&_ctx.inFlightFences[_ctx.currentFrame]);
-  if (!resetRes.has_value()) {
+  if (resetRes.errored()) {
     FLOG_ERROR("failed to reset in-flight fence");
     return FeErr{resetRes.error()};
   }
@@ -479,7 +479,7 @@ FeExpect<bool, Error> VulkanBackend::EndFrame(float32 deltaTime) {
                                   cSubmitCount,
                                   &submitInfo,
                                   _ctx.inFlightFences[_ctx.currentFrame].handle);
-  if (auto res = VkCheck(result); !res.has_value()) {
+  if (auto res = VkCheck(result); res.errored()) {
     FLOG_ERROR("failed to submit to graphics queue");
     return FeErr{res.error()};
   }
@@ -493,7 +493,7 @@ FeExpect<bool, Error> VulkanBackend::EndFrame(float32 deltaTime) {
                                          device.presentQueue,
                                          _ctx.queueCompleteSemaphores[_ctx.imageIndex],
                                          _ctx.imageIndex);
-  if (!presentRes.has_value()) {
+  if (presentRes.errored()) {
     FLOG_ERROR("failed to present swapchain image");
     return FeErr{presentRes.error()};
   }
@@ -514,7 +514,7 @@ FeExpect<void, Error> VulkanBackend::UpdateGlobalState(math::Mat4D projection,
   // TODO: other ubo properties
 
   auto updateRes = _vulkanShader.UpdateGlobalState(_ctx, _ctx.objectShader);
-  if (!updateRes.has_value()) {
+  if (updateRes.errored()) {
     FLOG_ERROR("failed to update global state");
     return FeErr{updateRes.error()};
   }
@@ -555,13 +555,13 @@ FeExpect<void, Error> VulkanBackend::CreateTexture(const string &name,
   VulkanBuffer staging;
   auto createRes =
       _bufferManager.CreateVulkanBuffer(_ctx, imageSize, usage, memFlags, FeTrue, &staging);
-  if (!createRes.has_value()) {
+  if (createRes.errored()) {
     FLOG_ERROR("failed to create vulkan buffer for texture");
     return FeErr{Error("texture creation failed", ErrorType::RendererVulkanError)};
   }
 
   auto loadRes = _bufferManager.LoadData(_ctx, staging, 0, imageSize, 0, pPixels);
-  if (!loadRes.has_value()) {
+  if (loadRes.errored()) {
     FLOG_ERROR("failed to load data for texture");
     return FeErr{Error("load texture failed", ErrorType::RendererVulkanError)};
   }
@@ -582,7 +582,7 @@ FeExpect<void, Error> VulkanBackend::CreateTexture(const string &name,
       FeTrue,
       VK_IMAGE_ASPECT_COLOR_BIT,
       filter);
-  if (!createRes.has_value()) {
+  if (createRes.errored()) {
     FLOG_ERROR("failed to create image for texture");
     return FeErr{Error("texture failed to create image", ErrorType::RendererVulkanError)};
   }
@@ -601,7 +601,7 @@ FeExpect<void, Error> VulkanBackend::CreateTexture(const string &name,
   auto submitRes = _cmdBufferManager.ImmediateSubmit(_ctx, pool, queue, tempFence, callback);
   vkDestroyFence(_ctx.device.logicalDevice, tempFence, _ctx.pAllocator);
   _bufferManager.DestroyVulkanBuffer(_ctx, &staging);
-  if (!submitRes.has_value()) {
+  if (submitRes.errored()) {
     FLOG_ERROR("failed to submit command buffer for texture creation");
     return FeErr{Error("texture creation failed during submit", ErrorType::RendererVulkanError)};
   }
@@ -632,7 +632,7 @@ FeExpect<void, Error> VulkanBackend::DestroyTexture(resources::Texture *pTexture
   }
 
   auto destroyRes = _imageManager.DestroyImage(_ctx, pTextureData->image);
-  if (!destroyRes.has_value()) {
+  if (destroyRes.errored()) {
     FLOG_ERROR("failed to destroy image for texture");
     return FeErr{Error("failed to destroy texture image", ErrorType::RendererVulkanError)};
   }
@@ -668,7 +668,7 @@ FeExpect<void, Error> VulkanBackend::CreateGeometry(uint32 id,
                                    vertexSize,
                                    _ctx.objectVertexBuffer,
                                    pVertices);
-  if (!uploadRes.has_value()) {
+  if (uploadRes.errored()) {
     vkDestroyFence(_ctx.device.logicalDevice, tempFence, _ctx.pAllocator);
     FLOG_ERROR("failed to upload data range in test");
     return FeErr{uploadRes.error()};
@@ -683,7 +683,7 @@ FeExpect<void, Error> VulkanBackend::CreateGeometry(uint32 id,
                               pIndices);
 
   vkDestroyFence(_ctx.device.logicalDevice, tempFence, _ctx.pAllocator);
-  if (!uploadRes.has_value()) {
+  if (uploadRes.errored()) {
     FLOG_ERROR("failed to upload index data");
     return FeErr{uploadRes.error()};
   }
@@ -693,7 +693,7 @@ FeExpect<void, Error> VulkanBackend::CreateGeometry(uint32 id,
   geom.indexBufferOffset = indexOffset;
   geom.indexCount = indexCount;
   auto insertRes = _geometries.Insert(id, geom);
-  if (!insertRes.has_value()) {
+  if (insertRes.errored()) {
     FLOG_ERROR("failed to insert geometry into hashmap");
     return FeErr{insertRes.error()};
   }
@@ -807,7 +807,7 @@ FeExpect<void, Error> VulkanBackend::CreateMaterial(resources::Material *pMateri
   allocInfo.pSetLayouts = &_ctx.objectShader.textureDescriptorSetLayout;
   if (auto res = VkCheck(vkAllocateDescriptorSets(
           _ctx.device.logicalDevice, &allocInfo, &pMatData->descriptorSet));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to allocate descriptor sets for material");
     return FeErr{res.error()};
   }
@@ -838,7 +838,7 @@ FeExpect<void, Error> VulkanBackend::DestroyMaterial(resources::Material *pMater
                                               _ctx.objectShader.textureDescriptorPool,
                                               1,
                                               &pMatData->descriptorSet));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to free descriptor set for material");
     return FeErr{res.error()};
   }
@@ -877,7 +877,7 @@ FeExpect<void, Error> VulkanBackend::CreateFence(Fence *pFence, bool signaled) {
 
   if (auto res = VkCheck(
           vkCreateFence(_ctx.device.logicalDevice, &createInfo, _ctx.pAllocator, &pFence->handle));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to create vulkan fence");
     return FeErr{res.error()};
   }
@@ -944,7 +944,7 @@ FeExpect<void, Error> VulkanBackend::ResetFence(Fence *pFence) {
 
   constexpr uint32 cFenceCount = 1;
   if (auto res = VkCheck(vkResetFences(_ctx.device.logicalDevice, cFenceCount, &pFence->handle));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to reset vulkan fence");
     return FeErr{res.error()};
   }
@@ -963,7 +963,7 @@ FeExpect<void, Error> VulkanBackend::CreateBuffers() {
   const uint64 cVertexBufferSize = sizeof(math::Vertex3D) * 1024 * 1024;
   auto createRes = _bufferManager.CreateVulkanBuffer(
       _ctx, cVertexBufferSize, usageFlags, memoryPropertyFlag, FeTrue, &_ctx.objectVertexBuffer);
-  if (!createRes.has_value()) {
+  if (createRes.errored()) {
     FLOG_ERROR("failed to create vulkan vertex buffer");
     return FeErr{createRes.error()};
   }
@@ -976,7 +976,7 @@ FeExpect<void, Error> VulkanBackend::CreateBuffers() {
   const uint64 cIndexBufferSize = sizeof(uint32) * 1024 * 1024;
   createRes = _bufferManager.CreateVulkanBuffer(
       _ctx, cIndexBufferSize, usageFlags, memoryPropertyFlag, FeTrue, &_ctx.objectIndexBuffer);
-  if (!createRes.has_value()) {
+  if (createRes.errored()) {
     FLOG_ERROR("failed to create vulkan index buffer");
     return FeErr{createRes.error()};
   }
@@ -999,20 +999,20 @@ FeExpect<void, Error> VulkanBackend::UploadDataRange(VkCommandPool pool,
 
   auto createRes =
       _bufferManager.CreateVulkanBuffer(_ctx, size, usageFlags, memoryFlags, FeTrue, &staging);
-  if (!createRes.has_value()) {
+  if (createRes.errored()) {
     FLOG_ERROR("failed to create vulkan buffer");
     return FeErr{createRes.error()};
   }
 
   auto loadRes = _bufferManager.LoadData(_ctx, staging, 0, size, 0, pData);
-  if (!loadRes.has_value()) {
+  if (loadRes.errored()) {
     FLOG_ERROR("failed to load data from vulkan buffer");
     return FeErr{loadRes.error()};
   }
 
   auto copyRes = _bufferManager.CopyBufferTo(
       _ctx, pool, fence, queue, staging.handle, 0, buffer.handle, offset, size);
-  if (!copyRes.has_value()) {
+  if (copyRes.errored()) {
     FLOG_ERROR("failed to copy buffer on upload");
     return FeErr{copyRes.error()};
   }
@@ -1032,7 +1032,7 @@ void VulkanBackend::TextureSubmitCallback(CommandBuffer cmd,
                                                            VK_IMAGE_LAYOUT_UNDEFINED,
                                                            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
-  if (!transitionRes.has_value()) {
+  if (transitionRes.errored()) {
     FLOG_ERROR("failed to transition image layout for texture upload");
     return;
   }
@@ -1059,7 +1059,7 @@ void VulkanBackend::TextureSubmitCallback(CommandBuffer cmd,
                                                       imageFormat,
                                                       VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                                                       VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-  if (!transitionRes.has_value()) {
+  if (transitionRes.errored()) {
     FLOG_ERROR("failed to transition image layout for texture upload");
     return;
   }

--- a/engine/src/Renderer/Vulkan/VulkanBackend.cc
+++ b/engine/src/Renderer/Vulkan/VulkanBackend.cc
@@ -425,6 +425,16 @@ FeExpect<bool, Error> VulkanBackend::BeginFrame(float32 deltaTime) {
     return FeFalse;
   }
 
+  // Wait for the previous frame that was using this swapchain image to finish,
+  // so we don't re-record a command buffer the GPU is still executing.
+  if (_ctx.imagesInFlight[_ctx.imageIndex] != VK_NULL_HANDLE) {
+    auto imageWaitRes = AwaitFence(_ctx.imagesInFlight[_ctx.imageIndex], UINT64_MAX);
+    if (imageWaitRes.errored()) {
+      FLOG_ERROR("failed to await image in-flight fence");
+      return FeErr{imageWaitRes.error()};
+    }
+  }
+
   CommandBuffer &cmdBuffer = _ctx.graphicsCommandBuffer[_ctx.imageIndex];
   _cmdBufferManager.ResetBuffer(_ctx, cmdBuffer);
   _cmdBufferManager.BeginBuffer(_ctx, cmdBuffer, FeFalse, FeFalse, FeFalse);
@@ -441,14 +451,6 @@ FeExpect<bool, Error> VulkanBackend::EndFrame(float32 deltaTime) {
 
   _renderpassManager.EndRenderpass(_ctx, &cmdBuffer, &_ctx.mainRenderpass);
   _cmdBufferManager.EndBuffer(_ctx, cmdBuffer);
-
-  if (_ctx.imagesInFlight[_ctx.imageIndex] != VK_NULL_HANDLE) {
-    auto awaitRes = AwaitFence(_ctx.imagesInFlight[_ctx.imageIndex], UINT64_MAX);
-    if (awaitRes.errored()) {
-      FLOG_ERROR("failed to await image in-flight fence");
-      return FeErr{awaitRes.error()};
-    }
-  }
 
   _ctx.imagesInFlight[_ctx.imageIndex] = &_ctx.inFlightFences[_ctx.currentFrame];
 

--- a/engine/src/Renderer/Vulkan/VulkanBuffer.cc
+++ b/engine/src/Renderer/Vulkan/VulkanBuffer.cc
@@ -30,7 +30,7 @@ FeExpect<void, Error> BufferManager::CreateVulkanBuffer(Context &ctx,
 
   if (auto res = VkCheck(
           vkCreateBuffer(ctx.device.logicalDevice, &bufferInfo, ctx.pAllocator, &pBuffer->handle));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to create buffer");
     return FeErr{res.error()};
   }
@@ -64,7 +64,7 @@ FeExpect<void, Error> BufferManager::CreateVulkanBuffer(Context &ctx,
   }
 
   auto bindRes = BindBuffer(ctx, *pBuffer, 0);
-  if (!bindRes.has_value()) {
+  if (bindRes.errored()) {
     FLOG_ERROR("failed to bind buffer on create");
     return FeErr{bindRes.error()};
   }
@@ -103,7 +103,7 @@ FeExpect<void, Error> BufferManager::ResizeBuffer(
   VkBuffer newBuffer;
   if (auto res = VkCheck(
           vkCreateBuffer(ctx.device.logicalDevice, &bufferInfo, ctx.pAllocator, &newBuffer));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to create new buffer on resize");
     return FeErr{res.error()};
   }
@@ -124,14 +124,14 @@ FeExpect<void, Error> BufferManager::ResizeBuffer(
   }
 
   if (auto res = VkCheck(vkBindBufferMemory(ctx.device.logicalDevice, newBuffer, newMemory, 0));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to bind new buffer memory");
     return FeErr{res.error()};
   }
 
   auto copyRes =
       CopyBufferTo(ctx, pool, 0, queue, buffer.handle, 0, newBuffer, 0, buffer.totalSize);
-  if (!copyRes.has_value()) {
+  if (copyRes.errored()) {
     FLOG_ERROR("failed to copy buffer");
     return FeErr{copyRes.error()};
   }
@@ -157,7 +157,7 @@ FeExpect<void, Error> BufferManager::ResizeBuffer(
 FeExpect<void, Error> BufferManager::BindBuffer(Context &ctx, VulkanBuffer &buffer, uint64 offset) {
   if (auto res = VkCheck(
           vkBindBufferMemory(ctx.device.logicalDevice, buffer.handle, buffer.memory, offset));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to bind buffer memory");
     return FeErr{res.error()};
   }
@@ -170,7 +170,7 @@ FeExpect<void *, Error> BufferManager::LockMemory(
   void *data;
   if (auto res =
           VkCheck(vkMapMemory(ctx.device.logicalDevice, buffer.memory, offset, size, flags, &data));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to map buffer memory");
     return FeErr{res.error()};
   }
@@ -191,7 +191,7 @@ FeExpect<void, Error> BufferManager::LoadData(Context &ctx,
   void *dataPtr;
   if (auto res = VkCheck(
           vkMapMemory(ctx.device.logicalDevice, buffer.memory, offset, size, flags, &dataPtr));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to map buffer memory");
     return FeErr{res.error()};
   }

--- a/engine/src/Renderer/Vulkan/VulkanCommandBufferManager.cc
+++ b/engine/src/Renderer/Vulkan/VulkanCommandBufferManager.cc
@@ -26,7 +26,7 @@ FeExpect<void, Error> CommandBufferManager::CreateBuffers(Context &ctx) {
   for (uint32 i = 0; i < ctx.swapchain.imageCount; i++) {
     if (ctx.graphicsCommandBuffer[i].state != CmdBufferState::NotAllocated) {
       auto freeRes = FreeBuffer(ctx, &ctx.graphicsCommandBuffer[i], ctx.device.graphicsCommandPool);
-      if (!freeRes.has_value()) {
+      if (freeRes.errored()) {
         FLOG_ERROR("failed to free buffer at index {}", i);
         return FeErr{freeRes.error()};
       }
@@ -34,7 +34,7 @@ FeExpect<void, Error> CommandBufferManager::CreateBuffers(Context &ctx) {
     _memoryManager.FZeroMemory(&ctx.graphicsCommandBuffer[i], sizeof(CommandBuffer));
     auto allocRes =
         AllocateBuffer(ctx, &ctx.graphicsCommandBuffer[i], ctx.device.graphicsCommandPool, FeTrue);
-    if (!allocRes.has_value()) {
+    if (allocRes.errored()) {
       FLOG_ERROR("failed to allocate buffer at inidex {}", i);
       return FeErr{allocRes.error()};
     }
@@ -55,7 +55,7 @@ FeExpect<void, Error> CommandBufferManager::DestroyBuffers(Context &ctx) {
     }
 
     auto freeRes = FreeBuffer(ctx, &ctx.graphicsCommandBuffer[i], ctx.device.graphicsCommandPool);
-    if (!freeRes.has_value()) {
+    if (freeRes.errored()) {
       FLOG_ERROR("failed to free buffer at index {}", i);
       return FeErr{freeRes.error()};
     }
@@ -80,7 +80,7 @@ FeExpect<void, Error> CommandBufferManager::AllocateBuffer(Context &ctx,
   pCmdBuffer->state = CmdBufferState::NotAllocated;
   if (auto res = VkCheck(
           vkAllocateCommandBuffers(ctx.device.logicalDevice, &allocInfo, &pCmdBuffer->handle));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to allocate command buffers");
     return FeErr{res.error()};
   }
@@ -114,7 +114,7 @@ void CommandBufferManager::BeginBuffer(Context &ctx,
     beginInfo.flags |= VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
   }
 
-  if (auto res = VkCheck(vkBeginCommandBuffer(cmdBuffer.handle, &beginInfo)); !res.has_value()) {
+  if (auto res = VkCheck(vkBeginCommandBuffer(cmdBuffer.handle, &beginInfo)); res.errored()) {
     FLOG_ERROR("failed to begin command buffer");
     return;
   }
@@ -122,7 +122,7 @@ void CommandBufferManager::BeginBuffer(Context &ctx,
 }
 
 void CommandBufferManager::EndBuffer(Context &ctx, CommandBuffer &cmdBuffer) {
-  if (auto res = VkCheck(vkEndCommandBuffer(cmdBuffer.handle)); !res.has_value()) {
+  if (auto res = VkCheck(vkEndCommandBuffer(cmdBuffer.handle)); res.errored()) {
     FLOG_ERROR("failed to end command buffer");
     return;
   }

--- a/engine/src/Renderer/Vulkan/VulkanCommandBufferManager.hpp
+++ b/engine/src/Renderer/Vulkan/VulkanCommandBufferManager.hpp
@@ -29,9 +29,9 @@ public:
 
     CommandBuffer tmp{};
     {
-      auto allocRes = AllocateBuffer(ctx, &tmp, pool, /*isPrimary=*/FeTrue);
-      if (!allocRes.has_value()) {
-        FLOG_ERROR("failed to allocate temp command buffer");
+      auto allocRes = AllocateBuffer(ctx, &tmp, pool, /*isPrimary=*/FeTrue)
+                          .or_error("failed to allocate temp command buffer");
+      if (allocRes.errored()) {
         return FeErr{allocRes.error()};
       }
     }
@@ -44,10 +44,8 @@ public:
 
     // Reset fence only if it's valid
     if (fence != VK_NULL_HANDLE) {
-      if (auto res = VkCheck(vkResetFences(ctx.device.logicalDevice, 1, &fence));
-          !res.has_value()) {
-        FLOG_ERROR("failed to reset fence");
-        auto _ = FreeBuffer(ctx, &tmp, pool);
+      if (auto res = VkCheck(vkResetFences(ctx.device.logicalDevice, 1, &fence)).or_error("failed to reset fence"); res.errored()) {
+        FreeBuffer(ctx, &tmp, pool).or_log_error("failed to free buffer on reset fence error");
         return FeErr{res.error()};
       }
     }
@@ -56,7 +54,7 @@ public:
     submitInfo.commandBufferCount = 1;
     submitInfo.pCommandBuffers = &tmp.handle;
 
-    if (auto res = VkCheck(vkQueueSubmit(queue, 1, &submitInfo, fence)); !res.has_value()) {
+    if (auto res = VkCheck(vkQueueSubmit(queue, 1, &submitInfo, fence)); res.errored()) {
       FLOG_ERROR("vkQueueSubmit failed");
       auto _ = FreeBuffer(ctx, &tmp, pool);
       return FeErr{res.error()};
@@ -66,13 +64,13 @@ public:
     if (fence != VK_NULL_HANDLE) {
       if (auto res =
               VkCheck(vkWaitForFences(ctx.device.logicalDevice, 1, &fence, VK_TRUE, UINT64_MAX));
-          !res.has_value()) {
+          res.errored()) {
         FLOG_ERROR("vkWaitForFences failed");
         auto _ = FreeBuffer(ctx, &tmp, pool);
         return FeErr{res.error()};
       }
     } else {
-      if (auto res = VkCheck(vkQueueWaitIdle(queue)); !res.has_value()) {
+      if (auto res = VkCheck(vkQueueWaitIdle(queue)); res.errored()) {
         FLOG_ERROR("vkQueueWaitIdle failed");
         auto _ = FreeBuffer(ctx, &tmp, pool);
         return FeErr{res.error()};
@@ -81,7 +79,7 @@ public:
 
     {
       auto freeRes = FreeBuffer(ctx, &tmp, pool);
-      if (!freeRes.has_value()) {
+      if (freeRes.errored()) {
         FLOG_ERROR("ImmediateSubmit: failed to free temp command buffer");
         return FeErr{freeRes.error()};
       }

--- a/engine/src/Renderer/Vulkan/VulkanDeviceManager.cc
+++ b/engine/src/Renderer/Vulkan/VulkanDeviceManager.cc
@@ -113,7 +113,7 @@ FeExpect<void, Error> DeviceManager::CreateDevice(Context &ctx) {
 
   if (auto res = VkCheck(vkCreateDevice(
           ctx.device.physicalDevice, &deviceCreateInfo, ctx.pAllocator, &ctx.device.logicalDevice));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_FATAL("failed to create logical device");
     return FeErr{res.error()};
   }
@@ -133,7 +133,7 @@ FeExpect<void, Error> DeviceManager::CreateDevice(Context &ctx) {
                                              &poolCreateInfo,
                                              ctx.pAllocator,
                                              &ctx.device.graphicsCommandPool));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_FATAL("failed to create command pool");
     return FeErr{res.error()};
   }
@@ -196,7 +196,7 @@ FeExpect<void, Error> DeviceManager::DestroyDevice(Context &ctx) {
 bool DeviceManager::SelectPhysicalDevice(Context &ctx) {
   uint32 physicalDeviceCount = 0;
   if (auto res = VkCheck(vkEnumeratePhysicalDevices(ctx.instance, &physicalDeviceCount, nullptr));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_FATAL("failed to enumerate physical devices: {}", res.error().message);
     return FeFalse;
   }
@@ -214,7 +214,7 @@ bool DeviceManager::SelectPhysicalDevice(Context &ctx) {
 
   if (auto res = VkCheck(
           vkEnumeratePhysicalDevices(ctx.instance, &physicalDeviceCount, physicalDevices.Data()));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_FATAL("failed to store enumerated physical devices: {}", res.error().message);
     return FeFalse;
   }
@@ -364,7 +364,7 @@ bool DeviceManager::PhysicalDeviceMeetsRequirements(VkPhysicalDevice device,
     VkBool32 supportsPresent = VK_FALSE;
     auto presRes =
         VkCheck(vkGetPhysicalDeviceSurfaceSupportKHR(device, i, surface, &supportsPresent));
-    if (!presRes.has_value()) {
+    if (presRes.errored()) {
       FLOG_FATAL("failed to get physical device surface support: {}", presRes.error().message);
       _memoryManager.RawFree(FeCast<std::byte>(queueFamilies),
                              sizeof(VkQueueFamilyProperties) * queueFamilyCount,
@@ -452,7 +452,7 @@ bool DeviceManager::PhysicalDeviceMeetsRequirements(VkPhysicalDevice device,
 
   FLOG_TRACE("swapchain queried");
 
-  if (!swapRes.has_value()) {
+  if (swapRes.errored()) {
     FLOG_ERROR("failed to query swapchain support: {}", swapRes.error().message);
     return FeFalse;
   }
@@ -467,7 +467,7 @@ bool DeviceManager::PhysicalDeviceMeetsRequirements(VkPhysicalDevice device,
     uint32 extCount = 0;
     if (auto res =
             VkCheck(vkEnumerateDeviceExtensionProperties(device, nullptr, &extCount, nullptr));
-        !res.has_value()) {
+        res.errored()) {
       FLOG_ERROR("failed to get device extension property count");
       return FeFalse;
     }

--- a/engine/src/Renderer/Vulkan/VulkanFrameBufferManager.cc
+++ b/engine/src/Renderer/Vulkan/VulkanFrameBufferManager.cc
@@ -50,7 +50,7 @@ FeExpect<void, Error> FrameBufferManager::CreateFrameBuffer(Context &ctx,
 
   if (auto res = VkCheck(vkCreateFramebuffer(
           ctx.device.logicalDevice, &createInfo, ctx.pAllocator, &pFrameBuffer->handle));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to create vulkan framebuffer");
     return FeErr{res.error()};
   }

--- a/engine/src/Renderer/Vulkan/VulkanImager.cc
+++ b/engine/src/Renderer/Vulkan/VulkanImager.cc
@@ -42,7 +42,7 @@ FeExpect<void, Error> ImageManager::CreateImage(Context &ctx,
 
   if (auto res = VkCheck(
           vkCreateImage(ctx.device.logicalDevice, &imgCreateInfo, ctx.pAllocator, &image.handle));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to create image");
     return FeErr{res.error()};
   }
@@ -61,14 +61,14 @@ FeExpect<void, Error> ImageManager::CreateImage(Context &ctx,
   memInfo.memoryTypeIndex = memType;
   if (auto res = VkCheck(vkAllocateMemory(
           ctx.device.logicalDevice, &memInfo, ctx.pAllocator, &image.deviceMemory));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to allocate memory for image");
     return FeErr{res.error()};
   }
 
   if (auto res =
           VkCheck(vkBindImageMemory(ctx.device.logicalDevice, image.handle, image.deviceMemory, 0));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to bind image memory");
     return FeErr{res.error()};
   }
@@ -80,7 +80,7 @@ FeExpect<void, Error> ImageManager::CreateImage(Context &ctx,
 
   image.view = nullptr;
   auto createRes = CreateImageView(ctx, image, format, aspectFlags);
-  if (!createRes.has_value()) {
+  if (createRes.errored()) {
     FLOG_ERROR("failed to create image view");
     return FeErr{createRes.error()};
   }
@@ -110,7 +110,7 @@ FeExpect<void, Error> ImageManager::CreateImageView(Context &ctx,
 
   if (auto res = VkCheck(vkCreateImageView(
           ctx.device.logicalDevice, &viewCreateInfo, ctx.pAllocator, &image.view));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to create image view");
     return FeErr{res.error()};
   }

--- a/engine/src/Renderer/Vulkan/VulkanPipeline.cc
+++ b/engine/src/Renderer/Vulkan/VulkanPipeline.cc
@@ -136,10 +136,12 @@ PipelineManager::CreateGraphicsPipeline(Context &ctx,
   pipelineLayoutInfo.pSetLayouts = pDescriptorLayouts;
   pipelineLayoutInfo.pushConstantRangeCount = 1;
   pipelineLayoutInfo.pPushConstantRanges = &pushConstant;
-  auto res = VkCheck(vkCreatePipelineLayout(
-      ctx.device.logicalDevice, &pipelineLayoutInfo, ctx.pAllocator, &pPipeline->layout));
-  if (!res.has_value()) {
-    FLOG_ERROR("failed to create pipeline layout");
+  auto res =
+      VkCheck(
+          vkCreatePipelineLayout(
+              ctx.device.logicalDevice, &pipelineLayoutInfo, ctx.pAllocator, &pPipeline->layout))
+          .or_error("failed to create pipeline layout");
+  if (res.errored()) {
     return FeErr{res.error()};
   }
 

--- a/engine/src/Renderer/Vulkan/VulkanRenderpassManager.cc
+++ b/engine/src/Renderer/Vulkan/VulkanRenderpassManager.cc
@@ -123,7 +123,7 @@ FeExpect<void, Error> RenderpassManager::CreateRenderpass(Context &ctx,
 
   if (auto res = VkCheck(vkCreateRenderPass(
           ctx.device.logicalDevice, &renderPassCreateInfo, ctx.pAllocator, &pRenderpass->handle));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to create renderpass");
     return FeErr{res.error()};
   }

--- a/engine/src/Renderer/Vulkan/VulkanSwapchainManager.cc
+++ b/engine/src/Renderer/Vulkan/VulkanSwapchainManager.cc
@@ -16,7 +16,7 @@ FeExpect<void, Error> QuerySwapchainSupport(VkPhysicalDevice device,
   // Surface capabilities
   if (res = VkCheck(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
           device, surface, &outSwapchainInfo.capabilities));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to get physical device surface capabilities");
     return FeErr{res.error()};
   }
@@ -24,7 +24,7 @@ FeExpect<void, Error> QuerySwapchainSupport(VkPhysicalDevice device,
   // Surface formats
   if (res = VkCheck(vkGetPhysicalDeviceSurfaceFormatsKHR(
           device, surface, &outSwapchainInfo.formatCount, nullptr));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to get physical device surface format count");
     return FeErr{res.error()};
   }
@@ -45,7 +45,7 @@ FeExpect<void, Error> QuerySwapchainSupport(VkPhysicalDevice device,
 
     if (res = VkCheck(vkGetPhysicalDeviceSurfaceFormatsKHR(
             device, surface, &outSwapchainInfo.formatCount, outSwapchainInfo.pFormats));
-        !res.has_value()) {
+        res.errored()) {
       FLOG_ERROR("failed to get phyiscal device surface formats");
       return FeErr{res.error()};
     }
@@ -54,7 +54,7 @@ FeExpect<void, Error> QuerySwapchainSupport(VkPhysicalDevice device,
   // Present mode
   if (res = VkCheck(vkGetPhysicalDeviceSurfacePresentModesKHR(
           device, surface, &outSwapchainInfo.presentModeCount, nullptr));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to get physical device surface present mode count");
     return FeErr{res.error()};
   }
@@ -75,7 +75,7 @@ FeExpect<void, Error> QuerySwapchainSupport(VkPhysicalDevice device,
 
     if (res = VkCheck(vkGetPhysicalDeviceSurfacePresentModesKHR(
             device, surface, &outSwapchainInfo.presentModeCount, outSwapchainInfo.pPresentMode));
-        !res.has_value()) {
+        res.errored()) {
       FLOG_ERROR("failed to get physical device surface present mode");
       return FeErr{res.error()};
     }
@@ -113,19 +113,19 @@ SwapchainManager::RecreateSwapchain(Context &ctx, uint32 &width, uint32 &height)
 
   auto queryRes = QuerySwapchainSupport(
       ctx.device.physicalDevice, ctx.surface, ctx.device.swapchainSupportInfo, _memoryManager);
-  if (!queryRes.has_value()) {
+  if (queryRes.errored()) {
     FLOG_ERROR("failed to query swapchain support");
     return FeErr{queryRes.error()};
   }
 
   auto detectRes = DetectDeviceDepthFormat(ctx.device);
-  if (!detectRes.has_value()) {
+  if (detectRes.errored()) {
     FLOG_ERROR("failed to detect device depth format");
     return FeErr{detectRes.error()};
   }
 
   auto recreateRes = RecreateLogic(ctx, &ctx.swapchain, width, height);
-  if (!recreateRes.has_value()) {
+  if (recreateRes.errored()) {
     FLOG_ERROR("swapchain recreation logic failed");
     return FeErr{recreateRes.error()};
   }
@@ -145,7 +145,7 @@ SwapchainManager::RecreateSwapchain(Context &ctx, uint32 &width, uint32 &height)
   ctx.mainRenderpass.height = ctx.framebufferHeight;
 
   auto fbRes = RegenerateFrameBuffer(ctx, &ctx.swapchain, &ctx.mainRenderpass);
-  if (!fbRes.has_value()) {
+  if (fbRes.errored()) {
     return FeErr{fbRes.error()};
   }
 
@@ -176,7 +176,7 @@ FeExpect<bool, Error> SwapchainManager::AcquireNextImage(Context &ctx,
     // This errors happens when resizing goes wrong for example
     // We simply recreate the swapchain in this case
     auto res = RecreateLogic(ctx, &swapchain, ctx.framebufferWidth, ctx.framebufferHeight);
-    if (!res.has_value()) {
+    if (res.errored()) {
       FLOG_ERROR("failed to recreate swapchain after VK_ERROR_OUT_OF_DATE_KHR");
       return FeErr{res.error()};
     }
@@ -214,7 +214,7 @@ FeExpect<void, Error> SwapchainManager::PresentSwapchain(Context &ctx,
   if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR) {
     // Must recreate
     auto res = RecreateSwapchain(ctx, ctx.framebufferWidth, ctx.framebufferHeight);
-    if (!res.has_value()) {
+    if (res.errored()) {
       FLOG_ERROR("failed to recreate swapchain after present returned out of "
                  "date or suboptimal");
       return FeErr{res.error()};
@@ -264,7 +264,7 @@ FeExpect<void, Error> SwapchainManager::RegenerateFrameBuffer(Context &ctx,
                                                            attachmentCount,
                                                            attachments);
 
-    if (!createRes.has_value()) {
+    if (createRes.errored()) {
       FLOG_ERROR("failed to create framebuffer at index {}", i);
       return FeErr{createRes.error()};
     }
@@ -289,7 +289,7 @@ SwapchainManager::CreateLogic(Context &ctx, Swapchain *pSwapchain, uint32 width,
 
   auto queryRes = QuerySwapchainSupport(
       ctx.device.physicalDevice, ctx.surface, ctx.device.swapchainSupportInfo, _memoryManager);
-  if (!queryRes.has_value()) {
+  if (queryRes.errored()) {
     FLOG_ERROR("swapchain support query failed");
     return FeErr{queryRes.error()};
   }
@@ -383,7 +383,7 @@ SwapchainManager::CreateLogic(Context &ctx, Swapchain *pSwapchain, uint32 width,
 
   if (auto res = VkCheck(vkCreateSwapchainKHR(
           ctx.device.logicalDevice, &createInfo, ctx.pAllocator, &pSwapchain->handle));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to create vulkan swapchain");
     return FeErr{res.error()};
   }
@@ -392,7 +392,7 @@ SwapchainManager::CreateLogic(Context &ctx, Swapchain *pSwapchain, uint32 width,
   pSwapchain->imageCount = 0;
   if (auto res = VkCheck(vkGetSwapchainImagesKHR(
           ctx.device.logicalDevice, pSwapchain->handle, &pSwapchain->imageCount, nullptr));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to get swapchain image count");
     return FeErr{res.error()};
   }
@@ -422,7 +422,7 @@ SwapchainManager::CreateLogic(Context &ctx, Swapchain *pSwapchain, uint32 width,
                                                  pSwapchain->handle,
                                                  &pSwapchain->imageCount,
                                                  pSwapchain->pImages));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to get swapchain images");
     return FeErr{res.error()};
   }
@@ -441,13 +441,13 @@ SwapchainManager::CreateLogic(Context &ctx, Swapchain *pSwapchain, uint32 width,
 
     if (auto res = VkCheck(vkCreateImageView(
             ctx.device.logicalDevice, &viewInfo, ctx.pAllocator, &pSwapchain->pViews[i]));
-        !res.has_value()) {
+        res.errored()) {
       FLOG_ERROR("failed to create image view for index {}", i);
       return FeErr{res.error()};
     }
   }
 
-  if (auto res = DetectDeviceDepthFormat(ctx.device); !res.has_value()) {
+  if (auto res = DetectDeviceDepthFormat(ctx.device); res.errored()) {
     FLOG_WARN("failed to find a supported depth format");
     ctx.device.depthFormat = VK_FORMAT_UNDEFINED;
   }
@@ -464,7 +464,7 @@ SwapchainManager::CreateLogic(Context &ctx, Swapchain *pSwapchain, uint32 width,
                                             VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
                                             FeTrue,
                                             VK_IMAGE_ASPECT_DEPTH_BIT);
-  if (!imageRes.has_value()) {
+  if (imageRes.errored()) {
     FLOG_ERROR("failed to create depth attachment image");
     return FeErr{imageRes.error()};
   }
@@ -484,7 +484,7 @@ FeExpect<void, Error> SwapchainManager::DestroyLogic(Context &ctx, Swapchain *pS
 
   for (uint32 i = 0; i < pSwapchain->imageCount; i++) {
     auto delRes = _frameBufferManager.DestroyFrameBuffer(ctx, &pSwapchain->framebuffers[i]);
-    if (!delRes.has_value()) {
+    if (delRes.errored()) {
       FLOG_ERROR("failed to delete frame buffer at index {}", i);
       return FeErr{delRes.error()};
     }
@@ -493,7 +493,7 @@ FeExpect<void, Error> SwapchainManager::DestroyLogic(Context &ctx, Swapchain *pS
 
   // Destroy image
   auto imageRes = _imageManager.DestroyImage(ctx, pSwapchain->depthAttachment);
-  if (!imageRes.has_value()) {
+  if (imageRes.errored()) {
     FLOG_ERROR("failed to destroy depth attachment image");
     return FeErr{imageRes.error()};
   }
@@ -527,13 +527,13 @@ FeExpect<void, Error> SwapchainManager::DestroyLogic(Context &ctx, Swapchain *pS
 FeExpect<void, Error>
 SwapchainManager::RecreateLogic(Context &ctx, Swapchain *pSwapchain, uint32 width, uint32 height) {
   auto destroyRes = DestroyLogic(ctx, pSwapchain);
-  if (!destroyRes.has_value()) {
+  if (destroyRes.errored()) {
     FLOG_ERROR("failed to destroy swapchain in recreate process");
     return FeErr{destroyRes.error()};
   }
 
   auto createRes = CreateLogic(ctx, pSwapchain, width, height);
-  if (!createRes.has_value()) {
+  if (createRes.errored()) {
     FLOG_ERROR("failed to create swapchain in recreate process");
     return FeErr{createRes.error()};
   }

--- a/engine/src/Renderer/Vulkan/VulkanUtils.cc
+++ b/engine/src/Renderer/Vulkan/VulkanUtils.cc
@@ -16,7 +16,7 @@ void ShaderModuleCleanup(Context &ctx,
   }
 
   auto closeRes = ctx.filesystem.CloseFile(fileHandle);
-  if (!closeRes.has_value()) {
+  if (closeRes.errored()) {
     FLOG_FATAL("failed to close file in cleanup stage");
   }
 }
@@ -41,7 +41,7 @@ FeExpect<bool, Error> CreateShaderModule(Context &ctx,
       VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
 
   auto openRes = ctx.filesystem.OpenFile(cFileName, platform::FileMode::Read);
-  if (!openRes.has_value()) {
+  if (openRes.errored()) {
     FLOG_ERROR("failed to open file at path {}: {}", cFileName.string(), openRes.error().message);
     return FeErr{openRes.error()};
   }
@@ -69,7 +69,7 @@ FeExpect<bool, Error> CreateShaderModule(Context &ctx,
   };
 
   auto readRes = ctx.filesystem.ReadFromFile(fileHandle, bytes);
-  if (!readRes.has_value()) {
+  if (readRes.errored()) {
     FLOG_ERROR("failed to read file at path {}: {}", cFileName.string(), readRes.error().message);
     ShaderModuleCleanup(ctx, fileHandle, words, fileSize);
     return FeErr{readRes.error()};
@@ -82,7 +82,7 @@ FeExpect<bool, Error> CreateShaderModule(Context &ctx,
                                               &pShaderStage[stageIndex].shaderModuleCreateInfo,
                                               ctx.pAllocator,
                                               &pShaderStage[stageIndex].handle));
-      !res.has_value()) {
+      res.errored()) {
     FLOG_ERROR("failed to create shader module");
     ShaderModuleCleanup(ctx, fileHandle, words, fileSize);
     return FeErr{res.error()};

--- a/engine/src/Renderer/Vulkan/VulkanUtils.cc
+++ b/engine/src/Renderer/Vulkan/VulkanUtils.cc
@@ -1,25 +1,11 @@
 #include "VulkanUtils.hpp"
 
+#include "BuiltinShaders.hpp"
 #include "Core/Logger.hpp"
-#include "Platform/Filesystem.hpp"
 #include "Resources/ResourceTypes.hpp"
 #include <vulkan/vulkan_core.h>
 
 namespace flatearth::renderer::vulkan {
-
-void ShaderModuleCleanup(Context &ctx,
-                         platform::FileHandle fileHandle,
-                         uint32 *pWords,
-                         uint64 fileSize) {
-  if (pWords != nullptr) {
-    ctx.memoryManager.RawFree(pWords, fileSize, memory::Tag::Renderer);
-  }
-
-  auto closeRes = ctx.filesystem.CloseFile(fileHandle);
-  if (closeRes.errored()) {
-    FLOG_FATAL("failed to close file in cleanup stage");
-  }
-}
 
 void EnsureGPUMatrixLayout(math::Mat4D &inProj, math::Mat4D &inView) {
   inProj = inProj.ToGPUMatrix();
@@ -32,59 +18,39 @@ FeExpect<bool, Error> CreateShaderModule(Context &ctx,
                                          VkShaderStageFlagBits stageFlag,
                                          uint32 stageIndex,
                                          ShaderStage *pShaderStage) {
-  const std::filesystem::path cFileName =
-      std::filesystem::path(std::format("assets/shaders/{}.{}.spv", name, typeStr));
+  const uint8_t *pCode = nullptr;
+  size_t codeSize = 0;
+
+  if (name == "Builtin.ObjectShader" && typeStr == "vert") {
+    pCode = shaders::kObjectShaderVert;
+    codeSize = shaders::kObjectShaderVertSize;
+  } else if (name == "Builtin.ObjectShader" && typeStr == "frag") {
+    pCode = shaders::kObjectShaderFrag;
+    codeSize = shaders::kObjectShaderFragSize;
+  } else {
+    FLOG_ERROR("no embedded shader for {}.{}", name, typeStr);
+    return FeErr{Error("unknown built-in shader", ErrorType::FileReadError)};
+  }
+
+  if (codeSize == 0 || (codeSize % 4) != 0) {
+    FLOG_ERROR("invalid embedded SPIR-V size for {}.{}: {} bytes", name, typeStr, codeSize);
+    return FeErr{Error("bad SPIR-V size", ErrorType::InvalidFileHandle)};
+  }
 
   ctx.memoryManager.FZeroMemory(&pShaderStage[stageIndex].shaderModuleCreateInfo,
                                 sizeof(VkShaderModuleCreateInfo));
   pShaderStage[stageIndex].shaderModuleCreateInfo.sType =
       VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-
-  auto openRes = ctx.filesystem.OpenFile(cFileName, platform::FileMode::Read);
-  if (openRes.errored()) {
-    FLOG_ERROR("failed to open file at path {}: {}", cFileName.string(), openRes.error().message);
-    return FeErr{openRes.error()};
-  }
-  platform::FileHandle fileHandle = openRes.value();
-
-  uint64 fileSize = ctx.filesystem.SizeOfFile(cFileName);
-  if (fileSize == 0 || (fileSize % 4) != 0) {
-    FLOG_ERROR("invalid SPIR-V size for path {}. Size: {}", cFileName.string(), fileSize);
-    ShaderModuleCleanup(ctx, fileHandle, nullptr, fileSize);
-    return FeErr{Error("bad SPIR-V file size", ErrorType::InvalidFileHandle)};
-  }
-
-  uint32 wordCount = static_cast<uint32>(fileSize / 4);
-  uint32 *words = static_cast<uint32 *>(
-      ctx.memoryManager.RawAlloc(fileSize, alignof(uint32), memory::Tag::Renderer));
-  if (words == nullptr) {
-    FLOG_ERROR("failed to allocate words for reading");
-    ShaderModuleCleanup(ctx, fileHandle, nullptr, fileSize);
-    return FeErr{Error("allocation failed", ErrorType::NullptrException)};
-  }
-
-  std::span<std::byte> bytes{
-      reinterpret_cast<std::byte *>(words),
-      fileSize,
-  };
-
-  auto readRes = ctx.filesystem.ReadFromFile(fileHandle, bytes);
-  if (readRes.errored()) {
-    FLOG_ERROR("failed to read file at path {}: {}", cFileName.string(), readRes.error().message);
-    ShaderModuleCleanup(ctx, fileHandle, words, fileSize);
-    return FeErr{readRes.error()};
-  }
-
-  pShaderStage[stageIndex].shaderModuleCreateInfo.codeSize = fileSize;
-  pShaderStage[stageIndex].shaderModuleCreateInfo.pCode = words;
+  pShaderStage[stageIndex].shaderModuleCreateInfo.codeSize = codeSize;
+  pShaderStage[stageIndex].shaderModuleCreateInfo.pCode =
+      reinterpret_cast<const uint32_t *>(pCode);
 
   if (auto res = VkCheck(vkCreateShaderModule(ctx.device.logicalDevice,
                                               &pShaderStage[stageIndex].shaderModuleCreateInfo,
                                               ctx.pAllocator,
                                               &pShaderStage[stageIndex].handle));
       res.errored()) {
-    FLOG_ERROR("failed to create shader module");
-    ShaderModuleCleanup(ctx, fileHandle, words, fileSize);
+    FLOG_ERROR("failed to create shader module for {}.{}", name, typeStr);
     return FeErr{res.error()};
   }
 
@@ -96,7 +62,6 @@ FeExpect<bool, Error> CreateShaderModule(Context &ctx,
   pShaderStage[stageIndex].shaderStageCreateInfo.module = pShaderStage[stageIndex].handle;
   pShaderStage[stageIndex].shaderStageCreateInfo.pName = "main";
 
-  ShaderModuleCleanup(ctx, fileHandle, words, fileSize);
   pShaderStage[stageIndex].shaderModuleCreateInfo.pCode = nullptr;
   pShaderStage[stageIndex].shaderModuleCreateInfo.codeSize = 0;
   return FeTrue;

--- a/engine/src/Resources/ResourceCache.hpp
+++ b/engine/src/Resources/ResourceCache.hpp
@@ -28,9 +28,8 @@ public:
       return;
     }
 
-    if (auto res = Destroy(&pEntry->resource); !res.has_value()) {
-      FLOG_FATAL("failed to destroy resource '{}' — GPU resource leaked", pEntry->name);
-    }
+    Destroy(&pEntry->resource)
+        .or_log_error("failed to destroy resource '{}' — GPU resource leaked", pEntry->name);
 
     _nameHandleMap.Erase(pEntry->name);
     _handleEntryMap.Erase(handle);
@@ -59,9 +58,8 @@ public:
                   pEntry->refCount);
       }
 
-      if (auto res = Destroy(&pEntry->resource); !res.has_value()) {
-        FLOG_FATAL("ResourceCache::Shutdown — failed to destroy '{}'", pEntry->name);
-      }
+      Destroy(&pEntry->resource)
+          .or_log_error("ResourceCache::Shutdown — failed to destroy '{}'", pEntry->name);
 
       _nameHandleMap.Erase(pEntry->name);
       _handleEntryMap.Erase(handle);
@@ -94,21 +92,24 @@ protected:
     entry.name = name;
     entry.refCount = 1;
 
-    if (auto res = Create(&entry.resource, _nextHandle, name); !res.has_value()) {
-      FLOG_ERROR("failed to create resource '{}'", name);
+    if (auto res = Create(&entry.resource, _nextHandle, name)
+                       .or_error("failed to create resource '{}'", name);
+        res.errored()) {
       return FeErr{res.error()};
     }
 
-    if (auto res = _nameHandleMap.Insert(name, _nextHandle); !res.has_value()) {
-      auto _ = Destroy(&entry.resource);
-      FLOG_ERROR("failed to cache name->handle for '{}'", name);
+    if (auto res = _nameHandleMap.Insert(name, _nextHandle)
+                       .or_error("failed to cache name->handle for '{}'", name);
+        res.errored()) {
+      Destroy(&entry.resource).or_log_error("failed to destroy resource");
       return FeErr{res.error()};
     }
 
-    if (auto res = _handleEntryMap.Insert(_nextHandle, entry); !res.has_value()) {
+    if (auto res = _handleEntryMap.Insert(_nextHandle, entry)
+                       .or_error("failed to cache handle->entry for '{}'", name);
+        res.errored()) {
       _nameHandleMap.Erase(name);
-      auto _ = Destroy(&entry.resource);
-      FLOG_ERROR("failed to cache handle->entry for '{}'", name);
+      Destroy(&entry.resource).or_log_error("failed to destroy resource");
       return FeErr{res.error()};
     }
 

--- a/engine/src/Resources/TextureCache.cc
+++ b/engine/src/Resources/TextureCache.cc
@@ -36,9 +36,8 @@ TextureCache::Create(Texture *pTexture, uint32 /*handle*/, const string &path) {
     return FeErr{Error("texture file not found", ErrorType::FileOpenError)};
   }
 
-  auto handleRes = _fs.OpenFile(path, platform::FileMode::Read, FeTrue);
-  if (!handleRes.has_value()) {
-    FLOG_ERROR("failed to open texture file: {}", path);
+  auto handleRes = _fs.OpenFile(path, platform::FileMode::Read, FeTrue).or_error("failed to open texture file");
+  if (handleRes.errored()) {
     return FeErr{handleRes.error()};
   }
 
@@ -51,12 +50,12 @@ TextureCache::Create(Texture *pTexture, uint32 /*handle*/, const string &path) {
   auto readRes = _fs.ReadFromFile(
       fileHandle, std::span<std::byte>(reinterpret_cast<std::byte *>(rawBytes.Data()), fileSize));
 
-  if (auto closeRes = _fs.CloseFile(fileHandle); !closeRes.has_value()) {
+  if (auto closeRes = _fs.CloseFile(fileHandle); closeRes.errored()) {
     FLOG_ERROR("failed to close texture file: {}", path);
     return FeErr{closeRes.error()};
   }
 
-  if (!readRes.has_value()) {
+  if (readRes.errored()) {
     FLOG_ERROR("failed to read texture file: {}", path);
     return FeErr{readRes.error()};
   }
@@ -76,7 +75,7 @@ TextureCache::Create(Texture *pTexture, uint32 /*handle*/, const string &path) {
 
   stbi_image_free(pPixels);
 
-  if (!texRes.has_value()) {
+  if (texRes.errored()) {
     FLOG_ERROR("failed to create texture from file: {}", path);
     return FeErr{texRes.error()};
   }

--- a/engine/src/Scene/Scene.hpp
+++ b/engine/src/Scene/Scene.hpp
@@ -3,19 +3,16 @@
 
 #include "Defines.hpp"
 
-#include <cstring>
-
 namespace flatearth::scene {
 
-constexpr uint32 cSceneNameMax = 64;
+using SceneId = uint16;
+constexpr SceneId cNullScene = 0;
 
 struct SceneOwnership {
-  char sceneName[cSceneNameMax]{};
+  SceneId sceneId{cNullScene};
 
   SceneOwnership() = default;
-  explicit SceneOwnership(stringv name) {
-    std::strncpy(sceneName, name.data(), cSceneNameMax - 1);
-  }
+  explicit SceneOwnership(SceneId id) : sceneId(id) {}
 };
 
 } // namespace flatearth::scene

--- a/engine/src/Scene/Systems/AudioSystem.cc
+++ b/engine/src/Scene/Systems/AudioSystem.cc
@@ -38,7 +38,7 @@ void AudioSystem::Update(Registry &registry, float32 delatTime) {
 
     if (!hasHandle) {
       auto res = _audio.AcquireSound(audioSrc.path);
-      if (!res.has_value()) {
+      if (res.errored()) {
         FLOG_ERROR("failed to acquire sound: {}", audioSrc.path);
         continue;
       }

--- a/engine/src/Scene/Systems/TransformSystem.cc
+++ b/engine/src/Scene/Systems/TransformSystem.cc
@@ -32,7 +32,7 @@ void TransformSystem::Update(ecs::Registry &registry, float32) {
       }
 
       auto res = matusalemSet.Insert(antecessorId);
-      if (!res.has_value()) {
+      if (res.errored()) {
         FLOG_ERROR("failed to insert entity '{}' into antecessor's (matusalem) map", antecessorId);
       }
       continue;

--- a/testbed/CMakeLists.txt
+++ b/testbed/CMakeLists.txt
@@ -155,46 +155,7 @@ add_custom_command(TARGET ${BINARY_NAME} POST_BUILD
 )
 
 ############################################################################
-#   RUNTIME ASSETS (assets/ next to executable + compile shaders to .spv)
-get_filename_component(REPO_ROOT "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
-
-set(ASSET_SRC_DIR  "${REPO_ROOT}/assets")
-set(SHADER_SRC_DIR "${ASSET_SRC_DIR}/shaders")
-
-set(RUNTIME_DIR     "$<TARGET_FILE_DIR:${BINARY_NAME}>")
-set(ASSET_OUT_DIR   "${RUNTIME_DIR}/assets")
-set(SHADER_OUT_DIR  "${ASSET_OUT_DIR}/shaders")
-
-# Find glslc (Windows + Linux)
-if(WIN32)
-  set(GLSLC "$ENV{VULKAN_SDK}/Bin/glslc.exe")
-else()
-  set(GLSLC "$ENV{VULKAN_SDK}/bin/glslc")
-endif()
-
-if(NOT EXISTS "${GLSLC}")
-  find_program(GLSLC glslc)
-endif()
-
-if(NOT GLSLC)
-  message(FATAL_ERROR "glslc not found. Install Vulkan SDK or put glslc in PATH / set VULKAN_SDK.")
-endif()
-
-add_custom_command(
-  TARGET ${BINARY_NAME}
-  POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E make_directory "${ASSET_OUT_DIR}"
-
-  COMMAND ${CMAKE_COMMAND} -E make_directory "${SHADER_OUT_DIR}"
-
-  COMMAND "${GLSLC}" -fshader-stage=vert
-          "${SHADER_SRC_DIR}/Builtin.ObjectShader.vert.glsl"
-          -o "${SHADER_OUT_DIR}/Builtin.ObjectShader.vert.spv"
-
-  COMMAND "${GLSLC}" -fshader-stage=frag
-          "${SHADER_SRC_DIR}/Builtin.ObjectShader.frag.glsl"
-          -o "${SHADER_OUT_DIR}/Builtin.ObjectShader.frag.spv"
-
-  COMMENT "Copying assets/ next to executable + compiling shaders to assets/shaders/*.spv"
-  VERBATIM
-)
+#   RUNTIME ASSETS
+# Built-in shaders are embedded in the engine library at compile time.
+# Only game assets (textures, tiles, audio) need to be deployed next to
+# the executable — handled by the root Makefile's asset-copy step.

--- a/testbed/src/Director.cc
+++ b/testbed/src/Director.cc
@@ -1,30 +1,19 @@
 #include "Director.hpp"
 
 #include <Core/Logger.hpp>
-#include <ECS/Registry.hpp>
-#include <Scene/Scene.hpp>
-
-#include <cstring>
-#include <vector>
 
 namespace flatearth::testbed {
 
-static const string sceneName_Playing    = "level1";
-static const string sceneName_MainMenu   = "main_menu";
-static const string sceneName_GameOver   = "game_over";
-static const string sceneName_GamePaused = "game_paused";
-
-static string PhaseToSceneName(GamePhase phase) {
-  switch (phase) {
-    case GamePhase::Playing:  return sceneName_Playing;
-    case GamePhase::MainMenu: return sceneName_MainMenu;
-    case GamePhase::GameOver: return sceneName_GameOver;
-    case GamePhase::Paused:   return sceneName_GamePaused;
-  }
-  return {};
+Orchestrator::Orchestrator(EngineContext &ctx) : _ctx(ctx) {
+  _sceneIds[static_cast<int>(GamePhase::MainMenu)] = ctx.project.RegisterScene("main_menu");
+  _sceneIds[static_cast<int>(GamePhase::Playing)]  = ctx.project.RegisterScene("level1");
+  _sceneIds[static_cast<int>(GamePhase::Paused)]   = ctx.project.RegisterScene("game_paused");
+  _sceneIds[static_cast<int>(GamePhase::GameOver)]  = ctx.project.RegisterScene("game_over");
 }
 
-Orchestrator::Orchestrator(EngineContext &ctx) : _ctx(ctx) {}
+scene::SceneId Orchestrator::PhaseToSceneId(GamePhase phase) const {
+  return _sceneIds[static_cast<int>(phase)];
+}
 
 void Orchestrator::RequestTransition(GamePhase phase) {
   _pendingPhase = phase;
@@ -38,18 +27,11 @@ void Orchestrator::Update(float32) {
 }
 
 void Orchestrator::ChangeScene() {
-  if (!_currentSceneName.empty()) {
-    auto &reg = _ctx.project.Registry();
-    std::vector<ecs::EntityId> toDestroy;
-    for (auto [id, ownership] : reg.ViewOf<scene::SceneOwnership>()) {
-      if (std::strncmp(ownership.sceneName, _currentSceneName.c_str(), scene::cSceneNameMax) == 0)
-        toDestroy.push_back(id);
-    }
-    for (auto id : toDestroy)
-      reg.Destroy(id);
+  if (_currentSceneId != scene::cNullScene) {
+    _ctx.project.DestroyScene(_currentSceneId);
   }
 
-  _currentSceneName = PhaseToSceneName(_pendingPhase);
+  _currentSceneId = PhaseToSceneId(_pendingPhase);
   _currentPhase = _pendingPhase;
 }
 

--- a/testbed/src/Director.hpp
+++ b/testbed/src/Director.hpp
@@ -2,6 +2,7 @@
 #define _FLATEARTH_TESTBED_DIRECTOR_HPP
 
 #include <Core/EngineContext.hpp>
+#include <Scene/Scene.hpp>
 
 namespace flatearth::testbed {
 
@@ -20,12 +21,14 @@ public:
 
 private:
   void ChangeScene();
+  scene::SceneId PhaseToSceneId(GamePhase phase) const;
 
 private:
   EngineContext &_ctx;
   GamePhase _currentPhase{GamePhase::MainMenu};
   GamePhase _pendingPhase{GamePhase::MainMenu};
-  string _currentSceneName{};
+  scene::SceneId _currentSceneId{scene::cNullScene};
+  scene::SceneId _sceneIds[4]{};
 };
 
 }

--- a/testbed/src/Entrypoint.cc
+++ b/testbed/src/Entrypoint.cc
@@ -24,12 +24,12 @@ int main(void) {
   }
 
   flatearth::Application app;
-  if (auto res = app.Initialize(gameInstance); !res.has_value()) {
+  if (auto res = app.Initialize(gameInstance); res.errored()) {
     LOG_ERROR("engine failed to initialize");
     return EXIT_FAILURE;
   }
 
-  if (auto res = app.Start(); !res.has_value()) {
+  if (auto res = app.Start(); res.errored()) {
     LOG_ERROR("engine failed to start");
     return EXIT_FAILURE;
   }

--- a/testbed/src/Game.cc
+++ b/testbed/src/Game.cc
@@ -19,9 +19,7 @@
 #include <Scene/Scene.hpp>
 #include <Scene/Systems/AudioSystem.hpp>
 #include <Scene/Systems/TransformSystem.hpp>
-#include <cstring>
 #include <imgui.h>
-#include <vector>
 
 namespace flatearth::testbed {
 
@@ -34,26 +32,20 @@ bool GameTest::GameLoad(flatearth::Game *gameInstance) {
 }
 
 void GameTest::GameRegisterSystems(flatearth::Game *gameInstance, ecs::SystemScheduler &scheduler) {
-  auto playerRes = scheduler.Register<PlayerSystem>(*gameInstance->pCtx, string("level1"));
-  if (!playerRes.has_value()) {
-    FLOG_FATAL("failed to register PlayerSystem: {}", playerRes.error().message);
-    std::exit(1);
-  }
-  playerRes.value().Before<systems::TransformSystem>();
+  EngineContext &ctx = *gameInstance->pCtx;
+  scene::SceneId level1 = ctx.project.RegisterScene("level1");
 
-  auto cameraRes = scheduler.Register<CameraFollowSystem>(*gameInstance->pCtx, string("level1"));
-  if (!cameraRes.has_value()) {
-    FLOG_FATAL("failed to register CameraFollowSystem: {}", cameraRes.error().message);
-    std::exit(1);
-  }
-  cameraRes.value().After<PlayerSystem>().Before<systems::TransformSystem>();
+  scheduler.Register<PlayerSystem>(ctx, level1)
+      .or_fatal("failed to register PlayerSystem")
+      .Before<systems::TransformSystem>();
 
-  auto worldRes = scheduler.Register<WorldSystem>(*gameInstance->pCtx, string("level1"));
-  if (!worldRes.has_value()) {
-    FLOG_FATAL("failed to register WorldSystem: {}", worldRes.error().message);
-    std::exit(1);
-  }
-  worldRes.value().Before<systems::AudioSystem>();
+  scheduler.Register<CameraFollowSystem>(ctx, level1)
+      .or_fatal("failed to register CameraFollowSystem")
+      .After<PlayerSystem>().Before<systems::TransformSystem>();
+
+  scheduler.Register<WorldSystem>(ctx, level1)
+      .or_fatal("failed to register WorldSystem")
+      .Before<systems::AudioSystem>();
 }
 
 // TODO: remove, just here for testing
@@ -167,15 +159,8 @@ void GameTest::GameUnload(flatearth::Game *gameInstance) {
 
   ctx.assets.Tilemap().Unload("assets/tiles/LevelEntrance.tmx");
 
-  std::vector<ecs::EntityId> toDestroy;
-  for (auto [id, ownership] : reg.ViewOf<scene::SceneOwnership>()) {
-    if (std::strncmp(ownership.sceneName, "level1", scene::cSceneNameMax) == 0) {
-      toDestroy.push_back(id);
-    }
-  }
-  for (auto id : toDestroy) {
-    reg.Destroy(id);
-  }
+  scene::SceneId level1 = ctx.project.GetSceneId("level1");
+  ctx.project.DestroyScene(level1);
 }
 
 void GameTest::Setup(flatearth::Game *gameInstance) {

--- a/testbed/src/Systems/CameraFollowSystem.cc
+++ b/testbed/src/Systems/CameraFollowSystem.cc
@@ -1,27 +1,27 @@
 #include "CameraFollowSystem.hpp"
+
+#include "../Components/Tags.hpp"
+
 #include <Scene/Components/Camera2D.hpp>
 #include <Scene/Components/Transform2D.hpp>
 #include <Scene/Scene.hpp>
 
-#include "../Components/Tags.hpp"
-
 namespace flatearth::testbed {
 
-CameraFollowSystem::CameraFollowSystem(EngineContext &ctx,
-                                       const string &sceneName)
-  : _ctx(ctx), _sceneName(sceneName) {}
+CameraFollowSystem::CameraFollowSystem(EngineContext &ctx, scene::SceneId sceneId)
+    : _ctx(ctx), _sceneId(sceneId) {
+}
 
 void CameraFollowSystem::Initialize(ecs::Registry &registry) {
-  ecs::EntityId cameraId = registry.Create();
-  const scene::SceneOwnership ownership{_sceneName};
-  registry.Insert(cameraId, scene::Transform2D{});
-  registry.Insert(cameraId, scene::Camera2D{.zoom = 0.2f});
-  registry.Insert(cameraId, ownership);
+  registry.Spawn()
+      .With(scene::Transform2D{})
+      .With(scene::Camera2D{.zoom = 0.2f})
+      .OwnedBy(_sceneId)
+      .Commit();
 
-  auto res = _ctx.core.KVarsRegistry().Register("camera.zoom", "Camera zoom scale", 0.2f);
-  if (!res.has_value()) {
-    FLOG_ERROR("failed to register camera zoom kvar");
-  }
+  _ctx.core.KVarsRegistry()
+      .Register("camera.zoom", "Camera zoom scale", 0.2f)
+      .or_log_error("failed to register camera zoom kvar");
 }
 
 void CameraFollowSystem::Update(ecs::Registry &registry, float32) {
@@ -44,4 +44,4 @@ void CameraFollowSystem::Update(ecs::Registry &registry, float32) {
   }
 }
 
-}
+} // namespace flatearth::testbed

--- a/testbed/src/Systems/CameraFollowSystem.hpp
+++ b/testbed/src/Systems/CameraFollowSystem.hpp
@@ -4,18 +4,19 @@
 #include <Core/EngineContext.hpp>
 #include <ECS/Registry.hpp>
 #include <ECS/SystemInterface.hpp>
+#include <Scene/Scene.hpp>
 
 namespace flatearth::testbed {
 
 class CameraFollowSystem : public ecs::ISystem {
 public:
-  explicit CameraFollowSystem(EngineContext &ctx, const string &sceneName);
+  explicit CameraFollowSystem(EngineContext &ctx, scene::SceneId sceneId);
   void Initialize(ecs::Registry &) override;
   void Update(ecs::Registry &, float32) override;
 
 private:
   EngineContext &_ctx;
-  string _sceneName;
+  scene::SceneId _sceneId;
 };
 
 } // namespace flatearth::testbed

--- a/testbed/src/Systems/PlayerSystem.cc
+++ b/testbed/src/Systems/PlayerSystem.cc
@@ -1,5 +1,7 @@
 #include "PlayerSystem.hpp"
 
+#include "../Components/Tags.hpp"
+
 #include <Core/EngineContext.hpp>
 #include <Core/Input.hpp>
 #include <Core/Logger.hpp>
@@ -8,32 +10,33 @@
 #include <Scene/Components/SpriteAnimator.hpp>
 #include <Scene/Components/Transform2D.hpp>
 #include <Scene/Scene.hpp>
-#include "../Components/Tags.hpp"
+#include <execution>
 
 namespace flatearth::testbed {
 
 static constexpr float32 kUVW = 32.0f / 128.0f;
 static constexpr float32 kUVH = 32.0f / 128.0f;
 
-PlayerSystem::PlayerSystem(EngineContext &ctx, string sceneName)
-    : _ctx(ctx), _sceneName(std::move(sceneName)) {}
+PlayerSystem::PlayerSystem(EngineContext &ctx, scene::SceneId sceneId)
+    : _ctx(ctx), _sceneId(sceneId) {
+}
 
 void PlayerSystem::Initialize(ecs::Registry &) {
-  auto kvarRes =
-      _ctx.core.KVarsRegistry().Register("player.speed", "Player movement speed (units/s)", 1.5f);
-  if (!kvarRes.has_value()) {
-    FLOG_ERROR("failed to register kvar for player speed");
-  }
+  _ctx.core.KVarsRegistry()
+      .Register("player.speed", "Player movement speed (units/s)", 1.5f)
+      .or_log_error("failed to register kvar for player speed");
 
-  _ctx.assets.Prefab().Register<PlayerPrefab>([&](ecs::EntityId id, ecs::Registry &reg) {
+  _ctx.assets.Prefab().Register<PlayerPrefab>([&](ecs::EntityBuilder &b) {
     auto walkTexRes = _ctx.assets.Manager().LoadTexture("assets/textures/Human_Walk.png");
-    if (!walkTexRes.has_value())
+    if (walkTexRes.errored()) {
       return;
+    }
 
     auto playerSpriteRes = _ctx.assets.Manager().SpriteFromTexture(
         walkTexRes.value(), "player_walk", resources::MeshShape::Quad);
-    if (!playerSpriteRes.has_value())
+    if (playerSpriteRes.errored()) {
       return;
+    }
 
     constexpr float32 uvW = 32.0f / 128.0f;
     constexpr float32 uvH = 32.0f / 128.0f;
@@ -55,82 +58,109 @@ void PlayerSystem::Initialize(ecs::Registry &) {
     playerSprite.uvScale = animator.frames[0].uvScale;
     playerSprite.layer = renderer::RenderLayer::Entities;
 
-    reg.Insert(id, scene::Transform2D{0.0f, 0.0f});
-    reg.Insert(id, playerSprite);
-    reg.Insert(id, animator);
-    reg.Insert(id, PlayerTag{});
-    reg.Insert(id, PlayerMovementState{});
-    // SceneOwnership already inserted by Spawn()
+    b.With(scene::Transform2D{0.0f, 0.0f})
+        .With(playerSprite)
+        .With(animator)
+        .With(PlayerTag{})
+        .With(PlayerMovementState{});
   });
 
-  auto playerRes = _ctx.assets.Prefab().Spawn<PlayerPrefab>(
-      _ctx.project.Registry(), scene::SceneOwnership{_sceneName});
-  if (!playerRes.has_value()) {
-    FLOG_ERROR("failed to spawn player: {}", playerRes.error().message);
+  auto playerRes = _ctx.assets.Prefab()
+                       .Spawn<PlayerPrefab>(_ctx.project.Registry(), _sceneId)
+                       .or_error("failed to spawn player prefab");
+  if (playerRes.errored()) {
     return;
   }
 
-  auto particleTexRes = _ctx.assets.Manager().LoadTexture("assets/textures/Human_Walk.png");
-  if (particleTexRes.has_value()) {
-    auto particleSprRes = _ctx.assets.Manager().SpriteFromTexture(
-        particleTexRes.value(), "particle_mat", resources::MeshShape::Quad);
-    if (particleSprRes.has_value()) {
-      scene::Sprite &ps = particleSprRes.value();
-
-      scene::ParticleEmitter emitter{};
-      emitter.texHandle = ps.texHandle;
-      emitter.matHandle = ps.matHandle;
-      emitter.meshHandle = ps.meshHandle;
-      emitter.velocityMin = {-0.3f, 0.2f};
-      emitter.velocityMax = {0.3f, 0.8f};
-      emitter.lifetimeMin = 0.3f;
-      emitter.lifetimeMax = 0.8f;
-      emitter.sizeStart = 0.04f;
-      emitter.sizeEnd = 0.0f;
-      emitter.spawnRate = 15.0f;
-
-      ecs::EntityId particleId = _ctx.project.Registry().Create();
-      _ctx.project.Registry().Insert(particleId, scene::Transform2D{});
-      _ctx.project.Registry().Insert(particleId, emitter);
-      _ctx.project.Registry().Insert(particleId, ParticleTag{});
-      _ctx.project.Registry().Insert(particleId, scene::SceneOwnership{_sceneName});
-    }
+  auto particleTexRes = _ctx.assets.Manager()
+                            .LoadTexture("assets/textures/Human_Walk.png")
+                            .or_error("failed to load particle texture");
+  if (particleTexRes.errored()) {
+    return;
   }
+
+  auto particleSprRes =
+      _ctx.assets.Manager()
+          .SpriteFromTexture(particleTexRes.value(), "particle_mat", resources::MeshShape::Quad)
+          .or_error("failed to create particle sprite from texture");
+  if (particleSprRes.errored()) {
+    return;
+  }
+
+  scene::Sprite &ps = particleSprRes.value();
+  scene::ParticleEmitter emitter{};
+  emitter.texHandle = ps.texHandle;
+  emitter.matHandle = ps.matHandle;
+  emitter.meshHandle = ps.meshHandle;
+  emitter.velocityMin = {-0.3f, 0.2f};
+  emitter.velocityMax = {0.3f, 0.8f};
+  emitter.lifetimeMin = 0.3f;
+  emitter.lifetimeMax = 0.8f;
+  emitter.sizeStart = 0.04f;
+  emitter.sizeEnd = 0.0f;
+  emitter.spawnRate = 15.0f;
+
+  _ctx.project.Registry()
+      .Spawn()
+      .With(scene::Transform2D{})
+      .With(emitter)
+      .With(ParticleTag{})
+      .OwnedBy(_sceneId)
+      .Commit();
 }
 
 void PlayerSystem::Update(ecs::Registry &, float32 deltaTime) {
-  auto &reg   = _ctx.project.Registry();
+  auto &reg = _ctx.project.Registry();
   auto &input = _ctx.core.Input();
   auto &kvars = _ctx.core.KVarsRegistry();
   float32 speed = kvars.Get<float32>("player.speed").value_or(1.5f);
 
-  for (auto [id, ptag, xform, sprite, anim, mv] :
-       reg.ViewOf<PlayerTag, scene::Transform2D, scene::Sprite,
-                  scene::SpriteAnimator, PlayerMovementState>()) {
+  for (auto [id, ptag, xform, sprite, anim, mv] : reg.ViewOf<PlayerTag,
+                                                             scene::Transform2D,
+                                                             scene::Sprite,
+                                                             scene::SpriteAnimator,
+                                                             PlayerMovementState>()) {
     float32 dx = 0.0f, dy = 0.0f;
 
-    if (input.IsKeyDown(input::KEY_W) || input.IsKeyDown(input::KEY_UP))
+    if (input.IsKeyDown(input::KEY_W) || input.IsKeyDown(input::KEY_UP)) {
       dy += 1.0f;
-    if (input.IsKeyDown(input::KEY_S) || input.IsKeyDown(input::KEY_DOWN))
+    }
+    if (input.IsKeyDown(input::KEY_S) || input.IsKeyDown(input::KEY_DOWN)) {
       dy -= 1.0f;
-    if (input.IsKeyDown(input::KEY_A) || input.IsKeyDown(input::KEY_LEFT))
+    }
+    if (input.IsKeyDown(input::KEY_A) || input.IsKeyDown(input::KEY_LEFT)) {
       dx -= 1.0f;
-    if (input.IsKeyDown(input::KEY_D) || input.IsKeyDown(input::KEY_RIGHT))
+    }
+    if (input.IsKeyDown(input::KEY_D) || input.IsKeyDown(input::KEY_RIGHT)) {
       dx += 1.0f;
+    }
 
     bool moving = (dx != 0.0f || dy != 0.0f);
 
-    if (dy > 0.0f) mv.vertRow = 3;
-    if (dy < 0.0f) mv.vertRow = 0;
-    if (dx < 0.0f) mv.horzRow = 1;
-    if (dx > 0.0f) mv.horzRow = 2;
+    if (dy > 0.0f) {
+      mv.vertRow = 3;
+    }
+    if (dy < 0.0f) {
+      mv.vertRow = 0;
+    }
+    if (dx < 0.0f) {
+      mv.horzRow = 1;
+    }
+    if (dx > 0.0f) {
+      mv.horzRow = 2;
+    }
 
     uint8 dirRow;
     if (dx != 0.0f && dy != 0.0f) {
-      if (dx < 0.0f && dy > 0.0f)      dirRow = 3;
-      else if (dx < 0.0f && dy < 0.0f) dirRow = 1;
-      else if (dx > 0.0f && dy < 0.0f) dirRow = 2;
-      else                              dirRow = 2;
+      if (dx < 0.0f && dy > 0.0f) {
+        dirRow = 3;
+      } else if (dx < 0.0f && dy < 0.0f) {
+        dirRow = 1;
+      } else if (dx > 0.0f && dy < 0.0f) {
+        dirRow = 2;
+      } else {
+        dirRow = 2;
+      }
     } else if (dx != 0.0f) {
       dirRow = mv.vertRow;
     } else if (dy != 0.0f) {
@@ -139,12 +169,13 @@ void PlayerSystem::Update(ecs::Registry &, float32 deltaTime) {
       dirRow = mv.lastDirRow;
     }
 
-    if (moving)
+    if (moving) {
       mv.lastDirRow = dirRow;
+    }
 
     for (uint8 col = 0; col < 4; ++col) {
       anim.frames[col].uvOffset = {col * kUVW, (dirRow + 1) * kUVH};
-      anim.frames[col].uvScale  = {kUVW, -kUVH};
+      anim.frames[col].uvScale = {kUVW, -kUVH};
     }
 
     anim.playing = moving;
@@ -153,7 +184,7 @@ void PlayerSystem::Update(ecs::Registry &, float32 deltaTime) {
       anim.elapsed = 0.0f;
     }
     sprite.uvOffset = anim.frames[anim.currentFrame].uvOffset;
-    sprite.uvScale  = anim.frames[anim.currentFrame].uvScale;
+    sprite.uvScale = anim.frames[anim.currentFrame].uvScale;
     sprite.dirty = FeTrue;
 
     xform.x += dx * speed * deltaTime;

--- a/testbed/src/Systems/PlayerSystem.hpp
+++ b/testbed/src/Systems/PlayerSystem.hpp
@@ -10,13 +10,13 @@ struct PlayerPrefab {};
 
 class PlayerSystem : public ecs::ISystem {
 public:
-  explicit PlayerSystem(EngineContext &ctx, string sceneName);
+  explicit PlayerSystem(EngineContext &ctx, scene::SceneId sceneId);
   void Initialize(ecs::Registry &) override;
   void Update(ecs::Registry &, float32) override;
 
 private:
   EngineContext &_ctx;
-  string _sceneName;
+  scene::SceneId _sceneId;
 };
 
 

--- a/testbed/src/Systems/WorldSystem.cc
+++ b/testbed/src/Systems/WorldSystem.cc
@@ -2,47 +2,36 @@
 
 #include "../Components/Tags.hpp"
 
+#include <Assets/TilemapManager.hpp>
 #include <Core/Logger.hpp>
 #include <Scene/Components/AudioSource.hpp>
 #include <Scene/Components/Utils.hpp>
 #include <Scene/Scene.hpp>
-#include <cstring>
-
-#include <Assets/TilemapManager.hpp>
 
 namespace flatearth::testbed {
 
-WorldSystem::WorldSystem(EngineContext &ctx, const string &sceneName)
-    : _ctx(ctx), _sceneName(sceneName) {
+WorldSystem::WorldSystem(EngineContext &ctx, scene::SceneId sceneId)
+    : _ctx(ctx), _sceneId(sceneId) {
 }
 
 void WorldSystem::Initialize(ecs::Registry &registry) {
-  auto res = _ctx.core.KVarsRegistry().Register(
-      "particle.spawnRate", "Particle emitter spawn rate (particles/s)", 15.0f);
-  if (!res.has_value()) {
-    FLOG_ERROR("failed to register particle spawn rate kvar");
-  }
+  _ctx.core.KVarsRegistry()
+                 .Register("particle.spawnRate", "Particle emitter spawn rate (particles/s)", 15.0f)
+                 .or_log_error("failed to register particle spawn rate kvar");
 
-  res = _ctx.core.KVarsRegistry().Register("bgm.volume", "BGM volume (0.0 - 2.0)", 1.0f);
-  if (!res.has_value()) {
-    FLOG_ERROR("failed to register bgm volume kvar");
-  }
+  _ctx.core.KVarsRegistry()
+      .Register("bgm.volume", "BGM volume (0.0 - 2.0)", 1.0f)
+      .or_log_error("failed to register bgm volume kvar");
 
-  auto tilemapRes = _ctx.assets.Tilemap().Load("assets/tiles/LevelEntrance.tmx", _sceneName);
-  if (!tilemapRes.has_value()) {
-    FLOG_ERROR("failed to load tilemap: {}", tilemapRes.error().message);
-  }
+  _ctx.assets.Tilemap()
+      .Load("assets/tiles/LevelEntrance.tmx", _sceneId)
+      .or_log_error("failed to load tilemap");
 
-  const scene::SceneOwnership ownership{_sceneName};
-  ecs::EntityId audioId = registry.Create();
   scene::AudioSource bgm{};
   scene::SetAudioPath(bgm, "assets/bgm/95.mp3");
   bgm.loop = FeTrue;
   bgm.playing = FeTrue;
-  registry.Insert(audioId, bgm);
-  registry.Insert(audioId, WorldTag{});
-  registry.Insert(audioId, ownership);
-
+  registry.Spawn().With(bgm).With(WorldTag{}).OwnedBy(_sceneId).Commit();
 }
 
 void WorldSystem::Update(ecs::Registry &registry, float32) {

--- a/testbed/src/Systems/WorldSystem.hpp
+++ b/testbed/src/Systems/WorldSystem.hpp
@@ -3,18 +3,19 @@
 
 #include <Core/EngineContext.hpp>
 #include <ECS/SystemInterface.hpp>
+#include <Scene/Scene.hpp>
 
 namespace flatearth::testbed {
 
 class WorldSystem : public ecs::ISystem {
 public:
-  explicit WorldSystem(EngineContext& ctx, const string &sceneName);
+  explicit WorldSystem(EngineContext& ctx, scene::SceneId sceneId);
   void Initialize(ecs::Registry &) override;
   void Update(ecs::Registry &, float32) override;
 
 private:
   EngineContext &_ctx;
-  string _sceneName{};
+  scene::SceneId _sceneId{scene::cNullScene};
 };
 
 }


### PR DESCRIPTION
This pull request introduces two major improvements: a refactor of error handling throughout the engine to use a more expressive and consistent pattern, and a redesign of the prefab and tilemap management APIs to use scene IDs instead of names. Additionally, it adds a new CMake-based pipeline for embedding built-in Vulkan shaders directly into the binary at build time.

**Error handling improvements:**

* Refactored error handling across the codebase to use `.errored()` and `.or_error(...)` for clearer, more expressive result checking and error propagation, replacing manual `.has_value()` checks and error logging. This affects asset loading, engine initialization, system registration, and command parsing. [[1]](diffhunk://#diff-27b43d82ec968fdb2d570a7d5dad647608cc8607f5350dba384d67e90551f901L41-R41) [[2]](diffhunk://#diff-27b43d82ec968fdb2d570a7d5dad647608cc8607f5350dba384d67e90551f901L55-R61) [[3]](diffhunk://#diff-27b43d82ec968fdb2d570a7d5dad647608cc8607f5350dba384d67e90551f901L80-R85) [[4]](diffhunk://#diff-411ea15ec788651c2241e8989a63ee44bc65c740cb319f90455b69197c381f73L73-R74) [[5]](diffhunk://#diff-5901ae29ccdc597072ce6b8cc4c4f22863d75830e42e656b754561f4dcd39b2bL36-R37) [[6]](diffhunk://#diff-31f59072a73cdc13361e6463f9509e222ab14742ab871a504d9420799bbe2535L22-R25) [[7]](diffhunk://#diff-31f59072a73cdc13361e6463f9509e222ab14742ab871a504d9420799bbe2535L34-R34) [[8]](diffhunk://#diff-06014678d18a220dac3c5e4ccb0d7395acf7ff5ef6f1e2e4f4618bc91a8fc07dL5-R16) [[9]](diffhunk://#diff-5799af7e1ca5b9643d9d6951c8c0ed7f7e3110c2efeca33796034ad616b05f57L67-R109) [[10]](diffhunk://#diff-5799af7e1ca5b9643d9d6951c8c0ed7f7e3110c2efeca33796034ad616b05f57R121-R128) [[11]](diffhunk://#diff-5799af7e1ca5b9643d9d6951c8c0ed7f7e3110c2efeca33796034ad616b05f57L178-R172) [[12]](diffhunk://#diff-5799af7e1ca5b9643d9d6951c8c0ed7f7e3110c2efeca33796034ad616b05f57L211-R228) [[13]](diffhunk://#diff-5799af7e1ca5b9643d9d6951c8c0ed7f7e3110c2efeca33796034ad616b05f57L246-R238) [[14]](diffhunk://#diff-d7d42271cba745817a148add2c200becff67b1825f00ac510283abfb81ef7c81L103-R103)

**Prefab and tilemap management API changes:**

* Updated `PrefabManager` and `TilemapManager` to use `scene::SceneId` instead of string names for scene ownership, improving type safety and consistency. The prefab registration API now uses `EntityBuilder` for entity construction. [[1]](diffhunk://#diff-d66ccd8087bc53b723fab2b224d125576c456d6b0f284c972f044e7da53fac35L6-R38) [[2]](diffhunk://#diff-d7c2ab3971c28700aea03952ceaf1d1967020ef4f80e1787917419716c3372afR10) [[3]](diffhunk://#diff-d7c2ab3971c28700aea03952ceaf1d1967020ef4f80e1787917419716c3372afL23-R24) [[4]](diffhunk://#diff-31f59072a73cdc13361e6463f9509e222ab14742ab871a504d9420799bbe2535L22-R25) [[5]](diffhunk://#diff-31f59072a73cdc13361e6463f9509e222ab14742ab871a504d9420799bbe2535L67-R67) [[6]](diffhunk://#diff-31f59072a73cdc13361e6463f9509e222ab14742ab871a504d9420799bbe2535L85-R85) [[7]](diffhunk://#diff-31f59072a73cdc13361e6463f9509e222ab14742ab871a504d9420799bbe2535L97-R97)

**Build system and shader embedding:**

* Added a CMake-based pipeline to automatically compile built-in GLSL shaders to SPIR-V using `glslc`, and embed them as header files (`BuiltinShaders.hpp`) for use in the engine. This ensures shaders are always up-to-date and available at runtime without external dependencies. [[1]](diffhunk://#diff-1292c6f7f812b50bda3b43b5a80a670c4c9a86cae1037cc760a75e45a1ae1f1aR172-R221) [[2]](diffhunk://#diff-1fe4ab10b4b0ac788f28b6109681c648d82a74656eb3da497baa4fc7ac2e9348R1-R33)

**Other improvements:**

* Minor code cleanups, such as improved file includes and formatting.