### PR TITLE
fix flaky ppa

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,20 +31,12 @@ jobs:
       - uses: actions/checkout@v4
 
       # ---------- Linux ----------
-      - name: Install GCC 14 (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-          sudo apt-get update
-          sudo apt-get install -y gcc-14 g++-14
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
-
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
+          sudo apt-get update
           sudo apt-get install -y \
-            cmake ninja-build \
+            cmake ninja-build g++-14 \
             libvulkan-dev vulkan-validationlayers glslc \
             libx11-dev libxcb1-dev libx11-xcb-dev \
             libxcb-keysyms1-dev libxcb-icccm4-dev \


### PR DESCRIPTION
This pull request simplifies the Linux build setup in the GitHub Actions release workflow by removing a dedicated step for installing GCC 14 and instead installs `g++-14` directly with other dependencies. This streamlines the workflow and reduces redundancy.

**Workflow simplification:**

* Removed the separate "Install GCC 14 (Linux)" step and its associated commands from `.github/workflows/release.yml`. (`[.github/workflows/release.ymlL34-R39](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L34-R39)`)
* Added `g++-14` to the list of packages installed in the "Install dependencies (Linux)" step, ensuring the required compiler is available without a separate installation process. (`[.github/workflows/release.ymlL34-R39](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L34-R39)`)