### PR TITLE
more fixes so that find_package works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
           done
 
           mkdir -p "$SDK_DIR/lib/cmake/Flatearth"
-          echo 'set(_prefix "${CMAKE_CURRENT_LIST_DIR}/../..")' > "$SDK_DIR/lib/cmake/Flatearth/FlatearthConfig.cmake"
+          echo 'set(_prefix "${CMAKE_CURRENT_LIST_DIR}/../../../")' > "$SDK_DIR/lib/cmake/Flatearth/FlatearthConfig.cmake"
           echo '' >> "$SDK_DIR/lib/cmake/Flatearth/FlatearthConfig.cmake"
           echo 'if(NOT TARGET flatearth::flatearth)' >> "$SDK_DIR/lib/cmake/Flatearth/FlatearthConfig.cmake"
           echo '  add_library(flatearth::flatearth SHARED IMPORTED)' >> "$SDK_DIR/lib/cmake/Flatearth/FlatearthConfig.cmake"
@@ -158,7 +158,7 @@ jobs:
           }
 
           New-Item -ItemType Directory -Force -Path "$SDK_DIR/lib/cmake/Flatearth" | Out-Null
-          Add-Content -Path "$SDK_DIR/lib/cmake/Flatearth/FlatearthConfig.cmake" -Value 'set(_prefix "${CMAKE_CURRENT_LIST_DIR}/../..")'
+          Add-Content -Path "$SDK_DIR/lib/cmake/Flatearth/FlatearthConfig.cmake" -Value 'set(_prefix "${CMAKE_CURRENT_LIST_DIR}/../../../")'
           Add-Content -Path "$SDK_DIR/lib/cmake/Flatearth/FlatearthConfig.cmake" -Value ''
           Add-Content -Path "$SDK_DIR/lib/cmake/Flatearth/FlatearthConfig.cmake" -Value 'if(NOT TARGET flatearth::flatearth)'
           Add-Content -Path "$SDK_DIR/lib/cmake/Flatearth/FlatearthConfig.cmake" -Value '  add_library(flatearth::flatearth SHARED IMPORTED)'

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ package:
 	  cp "$$f" "$(SDK_DIR)/include/$$rel"; \
 	done
 	mkdir -p $(SDK_DIR)/lib/cmake/Flatearth
-	printf 'set(_prefix "$${CMAKE_CURRENT_LIST_DIR}/../..")\nif(NOT TARGET flatearth::flatearth)\n  add_library(flatearth::flatearth SHARED IMPORTED)\n  find_library(_fe_lib NAMES flatearth libflatearth.so PATHS "$${_prefix}/lib" NO_DEFAULT_PATH)\n  set_target_properties(flatearth::flatearth PROPERTIES IMPORTED_LOCATION "$${_fe_lib}" INTERFACE_INCLUDE_DIRECTORIES "$${_prefix}/include")\nendif()\nif(NOT TARGET flatearth)\n  add_library(flatearth ALIAS flatearth::flatearth)\nendif()\n' > $(SDK_DIR)/lib/cmake/Flatearth/FlatearthConfig.cmake
+	printf 'set(_prefix "$${CMAKE_CURRENT_LIST_DIR}/../../../")\nif(NOT TARGET flatearth::flatearth)\n  add_library(flatearth::flatearth SHARED IMPORTED)\n  find_library(_fe_lib NAMES flatearth libflatearth.so PATHS "$${_prefix}/lib" NO_DEFAULT_PATH)\n  set_target_properties(flatearth::flatearth PROPERTIES IMPORTED_LOCATION "$${_fe_lib}" INTERFACE_INCLUDE_DIRECTORIES "$${_prefix}/include")\nendif()\nif(NOT TARGET flatearth)\n  add_library(flatearth ALIAS flatearth::flatearth)\nendif()\n' > $(SDK_DIR)/lib/cmake/Flatearth/FlatearthConfig.cmake
 	printf 'set(PACKAGE_VERSION "$(FE_VERSION)")\nif(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)\n  set(PACKAGE_VERSION_COMPATIBLE FALSE)\nelse()\n  set(PACKAGE_VERSION_COMPATIBLE TRUE)\n  if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)\n    set(PACKAGE_VERSION_EXACT TRUE)\n  endif()\nendif()\n' > $(SDK_DIR)/lib/cmake/Flatearth/FlatearthConfigVersion.cmake
 	tar -czf $(TARBALL) $(SDK_DIR)/
 	rm -rf $(SDK_DIR)


### PR DESCRIPTION
This pull request updates the way the `FlatearthConfig.cmake` file determines the CMake prefix path in the SDK packaging and release scripts. The main change is adjusting the relative path used for the `_prefix` variable to ensure correct resolution of library and include directories when the SDK is used.

**Build and packaging script updates:**

* Changed the `_prefix` variable in `FlatearthConfig.cmake` to use `"${CMAKE_CURRENT_LIST_DIR}/../../../"` instead of `"${CMAKE_CURRENT_LIST_DIR}/../.."` in all relevant scripts to fix incorrect path resolution. This affects the `Makefile`, the Linux/macOS release workflow (`.github/workflows/release.yml`), and the Windows release workflow (`.github/workflows/release.yml`). [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L49-R49) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L117-R117) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L161-R161)